### PR TITLE
Travis CI: OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
 - openjdk8
 - oraclejdk8
+- openjdk11
 addons:
   apt:
     packages:

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <version.iiif-apis>0.3.3</version.iiif-apis>
     <version.imageio-jnr>0.2.6</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
-    <version.jacoco-maven-plugin>0.7.9</version.jacoco-maven-plugin>
+    <version.jacoco-maven-plugin>0.8.2</version.jacoco-maven-plugin>
     <version.junit-platform-engine>1.1.1</version.junit-platform-engine>
     <version.junit-platform-launcher>1.1.0</version.junit-platform-launcher>
     <version.logstash-logback-encoder>5.1</version.logstash-logback-encoder>
@@ -109,10 +109,10 @@
     <!-- plugins -->
     <version.maven-compiler-plugin>3.7.0</version.maven-compiler-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
-    <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
+    <version.maven-javadoc-plugin>3.0.1</version.maven-javadoc-plugin>
     <version.maven-resources-plugin>3.1.0</version.maven-resources-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
-    <version.maven-surefire-plugin>2.19.1</version.maven-surefire-plugin>
+    <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
     <version.nexus-staging-maven-plugin>1.6.7</version.nexus-staging-maven-plugin>
   </properties>
 


### PR DESCRIPTION
This PR adds `openjdk11` to Travis CI build matrix.