### PR TITLE
Fix tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,1 +1,21 @@
 include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/.gitlab-ci-base.yml"
+
+variables:
+  MAVEN_VERIFY_PROFILE: "tests-without-libturbojpeg"
+
+verify:
+  extends: .verify
+  except:
+    variables:
+      - $NO_OPENJDK8
+  script: mvn $MAVEN_CLI_OPTS -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE -P$MAVEN_VERIFY_PROFILE verify
+
+verify:openjdk11:
+  extends: .verify
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
+  except:
+    variables:
+      - $NO_OPENJDK11
+  script: mvn $MAVEN_CLI_OPTS -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE -P$MAVEN_VERIFY_PROFILE verify
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,17 +5,17 @@ variables:
 
 verify:
   extends: .verify
-  except:
-    variables:
-      - $NO_OPENJDK8
   script: mvn $MAVEN_CLI_OPTS -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE -P$MAVEN_VERIFY_PROFILE verify
 
 verify:openjdk11:
   extends: .verify
   image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11"
-  except:
-    variables:
-      - $NO_OPENJDK11
   script: mvn $MAVEN_CLI_OPTS -Dspring.profiles.active=$MAVEN_ACTIVE_PROFILE -P$MAVEN_VERIFY_PROFILE verify
+  variables:
+    JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"
+
+verify:openjdk11:libturbjpeg:
+  extends: .verify
+  image: "$BUILD_IMAGE_ANSIBLE_MAVEN_JDK11_LIBTURBOJPEG"
   variables:
     JAVA_HOME: "/usr/lib/jvm/java-11-openjdk-amd64"

--- a/pom.xml
+++ b/pom.xml
@@ -499,6 +499,9 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>${version.maven-surefire-plugin}</version>
+        <configuration>
+          <excludedGroups>${excludeTags}</excludedGroups>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -632,6 +635,12 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>tests-without-libturbojpeg</id>
+      <properties>
+        <excludeTags>libturbojpeg-needed</excludeTags>
+      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
@@ -140,8 +140,6 @@ public class IIIFImageApiControllerTest {
     assertThat(ctx).jsonPathAsString("$.attribution").isEqualTo("Test Attribution");
   }
 
-  // TODO: find out why this does not work without libturbojpeg installed
-  @Tag("libturbojpeg-needed")
   @Test
   public void testInfoRedirect() throws Exception {
     ResponseEntity<String> response = restTemplate.getForEntity("/image/" + IIIFImageApiController.VERSION + "/abcdef", String.class);

--- a/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
@@ -22,6 +22,7 @@ import jnr.ffi.LibraryLoader;
 import jnr.ffi.Runtime;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,6 +67,7 @@ public class IIIFImageApiControllerTest {
     TestConfiguration.setDefaults();
   }
 
+  @Tag("libturbojpeg-needed")
   @Test
   public void testTurboJpegInstalled() {
     libturbojpeg lib = LibraryLoader.create(libturbojpeg.class)
@@ -96,6 +98,7 @@ public class IIIFImageApiControllerTest {
   }
 
   /* 5. Information Request */
+  @Tag("libturbojpeg-needed")
   @Test
   public void testImageInfo() throws Exception {
     HttpHeaders requestHeaders = new HttpHeaders();
@@ -137,6 +140,8 @@ public class IIIFImageApiControllerTest {
     assertThat(ctx).jsonPathAsString("$.attribution").isEqualTo("Test Attribution");
   }
 
+  // TODO: find out why this does not work without libturbojpeg installed
+  @Tag("libturbojpeg-needed")
   @Test
   public void testInfoRedirect() throws Exception {
     ResponseEntity<String> response = restTemplate.getForEntity("/image/" + IIIFImageApiController.VERSION + "/abcdef", String.class);


### PR DESCRIPTION
This PR fixes the unit tests in the containers that don't have `libturbojpeg` installed by adding tags to excluded these.