### PR TITLE
Bump imageio-jnr to 0.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <version.dc-commons>4.0.1</version.dc-commons>
     <version.guava>27.1-jre</version.guava>
     <version.iiif-apis>0.3.7</version.iiif-apis>
-    <version.imageio-jnr>0.3.2</version.imageio-jnr>
+    <version.imageio-jnr>0.4.0</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
     <version.javamelody>1.77.0</version.javamelody>
     <version.json-simple>1.1.1</version.json-simple>


### PR DESCRIPTION
- Adds support for ICC profiles in JPEG2000 images
- No longer crashes on JPEGs with CMYK color spaces