### PR TITLE
Always close ImageIO reader to prevent memory leaks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
     <version.dc-commons>4.0.1</version.dc-commons>
     <version.guava>27.1-jre</version.guava>
     <version.iiif-apis>0.3.7</version.iiif-apis>
-    <version.imageio-jnr>0.4.0</version.imageio-jnr>
+    <version.imageio-jnr>0.4.1-SNAPSHOT</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
     <version.javamelody>1.77.0</version.javamelody>
     <version.json-simple>1.1.1</version.json-simple>


### PR DESCRIPTION
We were very unhygeniec with our ImageIO readers, never calling `.dispose()`. This is usually not a problem with pure-Java ImageIO backends, but with the `OpenJp2` plugin from `imageio-jnr`, the reader held a reference to some off-heap memory (~1MiB per reader) that would be leaked without a call to `dispose()`.