### PR TITLE
Return 404 if the underlying HTTP resource cannot be read

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -21,6 +21,7 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -160,12 +161,16 @@ public class ImageServiceImpl implements ImageService {
     } catch (ResourceIOException e) {
       throw new ResourceNotFoundException();
     }
-    ImageInputStream iis = ImageIO.createImageInputStream(fileResourceService.getInputStream(fileResource));
-    ImageReader reader = Streams.stream(ImageIO.getImageReaders(iis))
-            .findFirst()
-            .orElseThrow(UnsupportedFormatException::new);
-    reader.setInput(iis);
-    return reader;
+    try {
+      ImageInputStream iis = ImageIO.createImageInputStream(fileResourceService.getInputStream(fileResource));
+      ImageReader reader = Streams.stream(ImageIO.getImageReaders(iis))
+          .findFirst()
+          .orElseThrow(UnsupportedFormatException::new);
+      reader.setInput(iis);
+      return reader;
+    } catch (FileNotFoundException e) {
+      throw new ResourceNotFoundException();
+    }
   }
 
   @Override


### PR DESCRIPTION
If the identifier resolves to a HTTP URI, the file repository will always return `true` on `find()`.
This led to 500 responses when trying to read from non-existing HTTP resources.
We now catch `FileNotFoundException`s when getting the actual input stream and return a `ResourceNotFoundException` there as well.