### PR TITLE
imageapi: Set Content-Type header last,

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
@@ -133,8 +133,6 @@ public class IIIFImageApiController {
       return null;
     } else {
       headers.add("Link", String.format("<%s>;rel=\"canonical\"", canonicalUrl));
-      final String mimeType = selector.getFormat().getMimeType().getTypeName();
-      headers.setContentType(MediaType.parseMediaType(mimeType));
 
       String filename = path.replaceFirst("/image/", "").replace('/', '_').replace(',', '_');
       headers.set("Content-Disposition", "inline; filename=" + filename);
@@ -149,6 +147,8 @@ public class IIIFImageApiController {
       customResponseHeaders.forImageTile().forEach(customResponseHeader -> {
         headers.set(customResponseHeader.getName(), customResponseHeader.getValue());
       });
+      final String mimeType = selector.getFormat().getMimeType().getTypeName();
+      headers.setContentType(MediaType.parseMediaType(mimeType));
       return new ResponseEntity<>(os.toByteArray(), headers, HttpStatus.OK);
     }
   }

--- a/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiControllerTest.java
@@ -38,7 +38,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static de.digitalcollections.iiif.hymir.HymirAssertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ExtendWith(SpringExtension.class)
@@ -520,6 +519,13 @@ public class IIIFImageApiControllerTest {
   public void testReadPNG() throws Exception {
     ResponseEntity<String> response = restTemplate.getForEntity("/image/" + IIIFImageApiController.VERSION + "/png-file/full/full/0/default.png", String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+  @Test
+  public void testNonExisting() {
+    ResponseEntity<String> response = restTemplate.getForEntity("/image/" + IIIFImageApiController.VERSION + "/idontexist/full/full/0/default.png", String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    assertThat(response.getHeaders().getContentType()).isNotEqualTo(MediaType.IMAGE_PNG);
   }
 
 }


### PR DESCRIPTION
In case of errors, this will lead to error messages having no content-type, rather than the image resource's content-type as before.