### PR TITLE
Add auto-formatting via google style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
+    <version.maven-fmt-plugin>2.9</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-surefire-plugin>3.0.0-M4</version.maven-surefire-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
@@ -395,6 +395,18 @@
 
     <plugins>
       <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.maven-fmt-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.github.spotbugs</groupId>
         <artifactId>spotbugs-maven-plugin</artifactId>
         <version>${version.spotbugs-maven-plugin}</version>
@@ -408,27 +420,6 @@
         </dependencies>
         <executions>
           <execution>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
-            </configuration>
             <goals>
               <goal>check</goal>
             </goals>

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/CustomResponseHeaders.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/CustomResponseHeaders.java
@@ -97,6 +97,5 @@ public class CustomResponseHeaders {
     public void setValue(String value) {
       this.value = value;
     }
-
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfig.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfig.java
@@ -6,12 +6,13 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
-@ComponentScan(basePackages = {
-  "de.digitalcollections.commons.springboot.actuator",
-  "de.digitalcollections.commons.springboot.contributor",
-  "de.digitalcollections.commons.springboot.metrics",
-  "de.digitalcollections.commons.springboot.monitoring"
-})
+@ComponentScan(
+    basePackages = {
+      "de.digitalcollections.commons.springboot.actuator",
+      "de.digitalcollections.commons.springboot.contributor",
+      "de.digitalcollections.commons.springboot.metrics",
+      "de.digitalcollections.commons.springboot.monitoring"
+    })
 @Configuration
 public class SpringConfig {
 

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendImage.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendImage.java
@@ -13,19 +13,15 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Backend configuration.
- */
+/** Backend configuration. */
 @Configuration
-@ComponentScan(basePackages = {
-    "de.digitalcollections.commons.file.config"
-})
+@ComponentScan(basePackages = {"de.digitalcollections.commons.file.config"})
 public class SpringConfigBackendImage {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SpringConfigBackendImage.class);
 
   static {
-    ImageIO.setUseCache(false);  // Use Heap memory for caching instead of disk
+    ImageIO.setUseCache(false); // Use Heap memory for caching instead of disk
 
     deregisterSunImageSpis();
     String[] readerMimeTypes = ImageIO.getReaderMIMETypes();
@@ -57,13 +53,22 @@ public class SpringConfigBackendImage {
   private static void deregisterSunImageSpis() {
     IIORegistry registry = IIORegistry.getDefaultInstance();
 
-    // We need to disable using the com.sun.imageio.* classes for tiff and jpeg due to strange runtime bugs.
+    // We need to disable using the com.sun.imageio.* classes for tiff and jpeg due to strange
+    // runtime bugs.
     // But we can just rely on the TwelveMonkeys imageio packages 🎉
-    // gif and png support is not provided by TwelveMonkeys (https://github.com/haraldk/TwelveMonkeys/issues/137)
-    // so we do not need to disable PNGImage{Reader,Writer}Spi and GIFImage{Reader, Writer}Spi for the com.sun.imageio.* classes here.
-    Set<String> spis = new HashSet<>(Arrays.asList("com.sun.imageio.plugins.tiff.TIFFImageReaderSpi", "com.sun.imageio.plugins.tiff.TIFFImageWriterSpi",
-        "com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi", "com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi",
-        "com.sun.imageio.plugins.bmp.BMPImageReaderSpi", "com.sun.imageio.plugins.bmp.BMPImageWriterSpi"));
+    // gif and png support is not provided by TwelveMonkeys
+    // (https://github.com/haraldk/TwelveMonkeys/issues/137)
+    // so we do not need to disable PNGImage{Reader,Writer}Spi and GIFImage{Reader, Writer}Spi for
+    // the com.sun.imageio.* classes here.
+    Set<String> spis =
+        new HashSet<>(
+            Arrays.asList(
+                "com.sun.imageio.plugins.tiff.TIFFImageReaderSpi",
+                "com.sun.imageio.plugins.tiff.TIFFImageWriterSpi",
+                "com.sun.imageio.plugins.jpeg.JPEGImageReaderSpi",
+                "com.sun.imageio.plugins.jpeg.JPEGImageWriterSpi",
+                "com.sun.imageio.plugins.bmp.BMPImageReaderSpi",
+                "com.sun.imageio.plugins.bmp.BMPImageWriterSpi"));
     for (String spi : spis) {
       try {
         Object spiProvider = registry.getServiceProviderByClass(Class.forName(spi));

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendPresentation.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendPresentation.java
@@ -3,12 +3,7 @@ package de.digitalcollections.iiif.hymir.config;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
-/**
- * Backend configuration.
- */
+/** Backend configuration. */
 @Configuration
-@ComponentScan(basePackages = {
-  "de.digitalcollections.commons.file.config"
-})
-public class SpringConfigBackendPresentation {
-}
+@ComponentScan(basePackages = {"de.digitalcollections.commons.file.config"})
+public class SpringConfigBackendPresentation {}

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigSecurity.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigSecurity.java
@@ -33,18 +33,26 @@ public class SpringConfigSecurity extends WebSecurityConfigurerAdapter {
 
   @Override
   protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-    auth.inMemoryAuthentication().passwordEncoder(passwordEncoderDummy())
+    auth.inMemoryAuthentication()
+        .passwordEncoder(passwordEncoderDummy())
         .withUser(User.withUsername(actuatorUsername).password(actuatorPassword).roles("ACTUATOR"));
   }
 
   @Override
   protected void configure(HttpSecurity http) throws Exception {
     // Monitoring:
-    // see https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints
-    http.antMatcher("/monitoring/**").authorizeRequests()
-        .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class)).permitAll()
-        .requestMatchers(EndpointRequest.to("prometheus", "version")).permitAll()
-        .requestMatchers(EndpointRequest.toAnyEndpoint()).hasRole("ACTUATOR").and().httpBasic();
+    // see
+    // https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#production-ready-endpoints
+    http.antMatcher("/monitoring/**")
+        .authorizeRequests()
+        .requestMatchers(EndpointRequest.to(InfoEndpoint.class, HealthEndpoint.class))
+        .permitAll()
+        .requestMatchers(EndpointRequest.to("prometheus", "version"))
+        .permitAll()
+        .requestMatchers(EndpointRequest.toAnyEndpoint())
+        .hasRole("ACTUATOR")
+        .and()
+        .httpBasic();
   }
 
   @Override
@@ -66,5 +74,4 @@ public class SpringConfigSecurity extends WebSecurityConfigurerAdapter {
       }
     };
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigWeb.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigWeb.java
@@ -24,7 +24,8 @@ public class SpringConfigWeb implements WebMvcConfigurer {
     localeChangeInterceptor.setParamName("language");
     registry.addInterceptor(localeChangeInterceptor);
 
-    CurrentUrlAsModelAttributeHandlerInterceptor currentUrlAsModelAttributeHandlerInterceptor = new CurrentUrlAsModelAttributeHandlerInterceptor();
+    CurrentUrlAsModelAttributeHandlerInterceptor currentUrlAsModelAttributeHandlerInterceptor =
+        new CurrentUrlAsModelAttributeHandlerInterceptor();
     currentUrlAsModelAttributeHandlerInterceptor.deleteParams("language");
     registry.addInterceptor(currentUrlAsModelAttributeHandlerInterceptor);
   }

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExtendedViewController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExtendedViewController.java
@@ -21,24 +21,27 @@ import org.springframework.web.bind.annotation.RequestMethod;
 /**
  * Controller for serving viewer page.
  *
- * Provides direct access to viewer for external call. Can be overwritten with custom behaviour.
+ * <p>Provides direct access to viewer for external call. Can be overwritten with custom behaviour.
  */
 @Controller
 public class ExtendedViewController {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ExtendedViewController.class);
 
-  @Autowired
-  private PresentationService presentationService;
+  @Autowired private PresentationService presentationService;
 
   @RequestMapping(value = "/presentation/{identifier}/view.html", method = RequestMethod.GET)
   public String viewExtendedPresentationGet(@PathVariable String identifier, Model model) {
-    model.addAttribute("presentationUri", "/presentation/" + IIIFPresentationApiController.VERSION + "/" + identifier);
+    model.addAttribute(
+        "presentationUri",
+        "/presentation/" + IIIFPresentationApiController.VERSION + "/" + identifier);
     return "mirador/view";
   }
 
   /**
-   * Direct link for viewing a specified canvas (page) used for citation.https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00107186/canvas/1
+   * Direct link for viewing a specified canvas (page) used for
+   * citation.https://api.digitale-sammlungen.de/iiif/presentation/v2/bsb00107186/canvas/1
+   *
    * @param version api version
    * @param objectIdentifier object identifier
    * @param canvasName name of canvas
@@ -49,8 +52,15 @@ public class ExtendedViewController {
    * @throws ResourceNotFoundException if manifest not found
    * @throws InvalidDataException if manifest can't be read
    */
-  @RequestMapping(value = "/presentation/{version}/{objectIdentifier}/canvas/{canvasName}/view", method = RequestMethod.GET)
-  public String viewCanvasGet(@PathVariable String version, @PathVariable String objectIdentifier, @PathVariable String canvasName, Model model, HttpServletRequest request)
+  @RequestMapping(
+      value = "/presentation/{version}/{objectIdentifier}/canvas/{canvasName}/view",
+      method = RequestMethod.GET)
+  public String viewCanvasGet(
+      @PathVariable String version,
+      @PathVariable String objectIdentifier,
+      @PathVariable String canvasName,
+      Model model,
+      HttpServletRequest request)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     HttpLoggingUtilities.addRequestClientInfoToMDC(request);
     MDC.put("manifestId", objectIdentifier);

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/GlobalControllerAdvice.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/GlobalControllerAdvice.java
@@ -6,9 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
-/**
- * Adds the webjar versions read from yaml files as global model attribute.
- */
+/** Adds the webjar versions read from yaml files as global model attribute. */
 @ControllerAdvice
 public class GlobalControllerAdvice {
 

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ViewController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ViewController.java
@@ -9,13 +9,13 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
-/**
- * Controller for serving different view pages.
- */
+/** Controller for serving different view pages. */
 @Controller
 public class ViewController {
 
-  @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"", "/"},
+      method = RequestMethod.GET)
   public String viewHomepage(Model model) {
     model.addAttribute("menu", "home");
     return "index";
@@ -23,7 +23,8 @@ public class ViewController {
 
   @RequestMapping(value = "/image/{identifier}/view.html", method = RequestMethod.GET)
   public String viewImageGet(@PathVariable String identifier, Model model) {
-    model.addAttribute("infoUrl", "/image/" + IIIFImageApiController.VERSION + "/" + identifier + "/info.json");
+    model.addAttribute(
+        "infoUrl", "/image/" + IIIFImageApiController.VERSION + "/" + identifier + "/info.json");
     return "openseadragon/view";
   }
 
@@ -39,17 +40,26 @@ public class ViewController {
 
   @RequestMapping(value = "/presentation/view/{identifier}", method = RequestMethod.GET)
   public String viewPresentationGet(@PathVariable String identifier, Model model) {
-    model.addAttribute("presentationUri", "/presentation/" + IIIFPresentationApiController.VERSION + "/" + identifier);
+    model.addAttribute(
+        "presentationUri",
+        "/presentation/" + IIIFPresentationApiController.VERSION + "/" + identifier);
     return "mirador/view";
   }
 
   @RequestMapping(value = "/presentation/manifest", method = RequestMethod.GET)
   public String viewPresentationManifest(@RequestParam String identifier) {
-    return "redirect:/presentation/" + IIIFPresentationApiController.VERSION + "/" + identifier + "/manifest";
+    return "redirect:/presentation/"
+        + IIIFPresentationApiController.VERSION
+        + "/"
+        + identifier
+        + "/manifest";
   }
 
   @RequestMapping(value = "/presentation/collection", method = RequestMethod.GET)
   public String viewPresentationCollection(@RequestParam String name) {
-    return "redirect:/presentation/" + IIIFPresentationApiController.VERSION + "/collection/" + name;
+    return "redirect:/presentation/"
+        + IIIFPresentationApiController.VERSION
+        + "/collection/"
+        + name;
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/api/ImageService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/api/ImageService.java
@@ -9,9 +9,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.time.Instant;
 
-/**
- * Service providing image processing functionality.
- */
+/** Service providing image processing functionality. */
 public interface ImageService {
 
   default Instant getImageModificationDate(String identifier) throws ResourceNotFoundException {
@@ -19,10 +17,11 @@ public interface ImageService {
   }
 
   void readImageInfo(String identifier, de.digitalcollections.iiif.model.image.ImageService info)
-          throws UnsupportedFormatException, UnsupportedOperationException, ResourceNotFoundException, IOException;
+      throws UnsupportedFormatException, UnsupportedOperationException, ResourceNotFoundException,
+          IOException;
 
-  void processImage(String identifier, ImageApiSelector selector, ImageApiProfile profile, OutputStream os)
-          throws InvalidParametersException, UnsupportedOperationException, UnsupportedFormatException,
+  void processImage(
+      String identifier, ImageApiSelector selector, ImageApiProfile profile, OutputStream os)
+      throws InvalidParametersException, UnsupportedOperationException, UnsupportedFormatException,
           ResourceNotFoundException, IOException;
-
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/model/exception/InvalidParametersException.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/model/exception/InvalidParametersException.java
@@ -2,8 +2,7 @@ package de.digitalcollections.iiif.hymir.model.exception;
 
 public class InvalidParametersException extends Exception {
 
-  public InvalidParametersException() {
-  }
+  public InvalidParametersException() {}
 
   public InvalidParametersException(String message) {
     super(message);

--- a/src/main/java/de/digitalcollections/iiif/hymir/model/exception/ResolvingException.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/model/exception/ResolvingException.java
@@ -12,7 +12,8 @@ public class ResolvingException extends Exception {
     super(message);
   }
 
-  public ResolvingException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+  public ResolvingException(
+      String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
     super(message, cause, enableSuppression, writableStackTrace);
   }
 

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
@@ -25,7 +25,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Repository;
 
 /**
- * Default implementation trying to get manifest.json from an resolved URI as String and returning Manifest instance.
+ * Default implementation trying to get manifest.json from an resolved URI as String and returning
+ * Manifest instance.
  */
 @Repository
 public class PresentationRepositoryImpl implements PresentationRepository {
@@ -33,14 +34,13 @@ public class PresentationRepositoryImpl implements PresentationRepository {
   private static final String COLLECTION_PREFIX = "collection-";
   private static final Logger LOGGER = LoggerFactory.getLogger(PresentationRepositoryImpl.class);
 
-  @Autowired
-  private IiifObjectMapper objectMapper;
+  @Autowired private IiifObjectMapper objectMapper;
 
-  @Autowired
-  private ResolvedFileResourceServiceImpl resourceService;
+  @Autowired private ResolvedFileResourceServiceImpl resourceService;
 
   @Override
-  public AnnotationList getAnnotationList(String identifier, String name, String canvasId) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  public AnnotationList getAnnotationList(String identifier, String name, String canvasId)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     String annotationListName = name + "-" + identifier + "_" + canvasId;
     FileResource resource;
     try {
@@ -53,12 +53,14 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       return objectMapper.readValue(getResourceJson(resource.getUri()), AnnotationList.class);
     } catch (IOException ex) {
       LOGGER.error("Could not retrieve annotation list {}", annotationListName, ex);
-      throw new InvalidDataException("Annotation list " + annotationListName + " can not be parsed", ex);
+      throw new InvalidDataException(
+          "Annotation list " + annotationListName + " can not be parsed", ex);
     }
   }
 
   @Override
-  public Collection getCollection(String name) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  public Collection getCollection(String name)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     // to get a regex resolvable pattern we add a static prefix for collections
     String collectionName = COLLECTION_PREFIX + name;
     FileResource resource;
@@ -72,12 +74,14 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       return objectMapper.readValue(getResourceJson(resource.getUri()), Collection.class);
     } catch (IOException ex) {
       LOGGER.info("Could not retrieve collection {}", collectionName, ex);
-      throw new InvalidDataException("Collection for name " + collectionName + " can not be parsed", ex);
+      throw new InvalidDataException(
+          "Collection for name " + collectionName + " can not be parsed", ex);
     }
   }
 
   @Override
-  public Manifest getManifest(String identifier) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  public Manifest getManifest(String identifier)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     FileResource resource;
     try {
       resource = resourceService.find(identifier, MimeType.MIME_APPLICATION_JSON);
@@ -94,26 +98,31 @@ public class PresentationRepositoryImpl implements PresentationRepository {
   }
 
   @Override
-  public Instant getManifestModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  public Instant getManifestModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return getResourceModificationDate(identifier);
   }
 
   @Override
-  public Instant getCollectionModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  public Instant getCollectionModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return getResourceModificationDate(identifier);
   }
 
-  private Instant getResourceModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  private Instant getResourceModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     try {
       FileResource resource = resourceService.find(identifier, MimeType.MIME_APPLICATION_JSON);
       return resource.getLastModified().toInstant(ZoneOffset.UTC);
     } catch (ResourceIOException ex) {
-      LOGGER.error("Error getting resource for identifier '{}', message '{}'", identifier, ex.getMessage());
+      LOGGER.error(
+          "Error getting resource for identifier '{}', message '{}'", identifier, ex.getMessage());
       throw new ResolvingException("No manifest for identifier " + identifier);
     }
   }
 
-  protected String getResourceJson(URI resourceUri) throws ResolvingException, ResourceNotFoundException {
+  protected String getResourceJson(URI resourceUri)
+      throws ResolvingException, ResourceNotFoundException {
     try (InputStream is = resourceService.getInputStream(resourceUri)) {
       return IOUtils.toString(is, StandardCharsets.UTF_8);
     } catch (IOException e) {

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/api/PresentationRepository.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/api/PresentationRepository.java
@@ -8,9 +8,7 @@ import de.digitalcollections.iiif.model.sharedcanvas.Manifest;
 import de.digitalcollections.model.api.identifiable.resource.exceptions.ResourceNotFoundException;
 import java.time.Instant;
 
-/**
- * Interface to be implemented by project/user of this library.
- */
+/** Interface to be implemented by project/user of this library. */
 public interface PresentationRepository {
 
   /**
@@ -22,7 +20,8 @@ public interface PresentationRepository {
    * @throws ResourceNotFoundException if annotation list with given name can not be found
    * @throws InvalidDataException if data is corrupted
    */
-  AnnotationList getAnnotationList(String identifier, String name, String canvasId) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  AnnotationList getAnnotationList(String identifier, String name, String canvasId)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
   /**
    * @param name unique name of collection
@@ -31,7 +30,8 @@ public interface PresentationRepository {
    * @throws ResourceNotFoundException if Collection with given name can not be found
    * @throws InvalidDataException if collection contains invalid data
    */
-  Collection getCollection(String name) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  Collection getCollection(String name)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
   /**
    * @param identifier unique id for IIIF resource
@@ -40,13 +40,16 @@ public interface PresentationRepository {
    * @throws ResourceNotFoundException if Manifest with given identifier can not be found
    * @throws InvalidDataException if manifest contains invalid data
    */
-  Manifest getManifest(String identifier) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  Manifest getManifest(String identifier)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
-  default Instant getManifestModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  default Instant getManifestModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return null;
   }
 
-  default Instant getCollectionModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  default Instant getCollectionModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return null;
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/PresentationServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/PresentationServiceImpl.java
@@ -21,37 +21,44 @@ public class PresentationServiceImpl implements PresentationService {
   private final PresentationSecurityService presentationSecurityService;
 
   @Autowired
-  public PresentationServiceImpl(PresentationRepository presentationRepository,
-          @Autowired(required = false) PresentationSecurityService presentationSecurityService) {
+  public PresentationServiceImpl(
+      PresentationRepository presentationRepository,
+      @Autowired(required = false) PresentationSecurityService presentationSecurityService) {
     this.presentationRepository = presentationRepository;
     this.presentationSecurityService = presentationSecurityService;
   }
 
   @Override
-  public AnnotationList getAnnotationList(String identifier, String name, String canvasId) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  public AnnotationList getAnnotationList(String identifier, String name, String canvasId)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     return presentationRepository.getAnnotationList(identifier, name, canvasId);
   }
 
   @Override
-  public Collection getCollection(String name) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  public Collection getCollection(String name)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     return presentationRepository.getCollection(name);
   }
 
   @Override
-  public Manifest getManifest(String identifier) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
-    if (presentationSecurityService != null && !presentationSecurityService.isAccessAllowed(identifier)) {
+  public Manifest getManifest(String identifier)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+    if (presentationSecurityService != null
+        && !presentationSecurityService.isAccessAllowed(identifier)) {
       throw new ResolvingException(); // TODO maybe throw an explicitely access disallowed exception
     }
     return presentationRepository.getManifest(identifier);
   }
 
   @Override
-  public Instant getManifestModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  public Instant getManifestModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return presentationRepository.getManifestModificationDate(identifier);
   }
 
   @Override
-  public Instant getCollectionModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  public Instant getCollectionModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return presentationRepository.getCollectionModificationDate(identifier);
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationSecurityService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationSecurityService.java
@@ -1,8 +1,6 @@
 package de.digitalcollections.iiif.hymir.presentation.business.api;
 
-/**
- * Service responsible for deciding if object (identified by identifier) is accessible.
- */
+/** Service responsible for deciding if object (identified by identifier) is accessible. */
 public interface PresentationSecurityService {
 
   boolean isAccessAllowed(String identifier);

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationService.java
@@ -13,9 +13,7 @@ import de.digitalcollections.model.api.identifiable.resource.exceptions.Resource
 import java.net.URI;
 import java.time.Instant;
 
-/**
- * Service for IIIF Presentation API functionality.
- */
+/** Service for IIIF Presentation API functionality. */
 public interface PresentationService {
 
   /**
@@ -25,7 +23,8 @@ public interface PresentationService {
    * @throws ResourceNotFoundException if annotation list with given name can not be found
    * @throws InvalidDataException if data is corrupted
    */
-  AnnotationList getAnnotationList(String identifier, String name, String canvasId) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  AnnotationList getAnnotationList(String identifier, String name, String canvasId)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
   /**
    * @param name unique name of collection
@@ -34,7 +33,8 @@ public interface PresentationService {
    * @throws ResourceNotFoundException if collection with given name can not be found
    * @throws InvalidDataException if data is corrupted
    */
-  Collection getCollection(String name) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  Collection getCollection(String name)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
   /**
    * @param identifier unique id for IIIF resource
@@ -43,51 +43,63 @@ public interface PresentationService {
    * @throws ResourceNotFoundException if Manifest with given identifier can not be found
    * @throws InvalidDataException if data is corrupted
    */
-  Manifest getManifest(String identifier) throws ResolvingException, ResourceNotFoundException, InvalidDataException;
+  Manifest getManifest(String identifier)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException;
 
-  default Instant getManifestModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  default Instant getManifestModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return Instant.now();
   }
 
-  default Instant getCollectionModificationDate(String identifier) throws ResolvingException, ResourceNotFoundException {
+  default Instant getCollectionModificationDate(String identifier)
+      throws ResolvingException, ResourceNotFoundException {
     return Instant.now();
   }
 
-  default Canvas getCanvas(String manifestId, String canvasUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Canvas getCanvas(String manifestId, String canvasUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     return getCanvas(manifestId, URI.create(canvasUri));
   }
 
-  default Canvas getCanvas(String manifestId, URI canvasUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Canvas getCanvas(String manifestId, URI canvasUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     Manifest manifest = getManifest(manifestId);
     return manifest.getSequences().stream()
-            .flatMap(seq -> seq.getCanvases().stream())
-            .filter(canv -> canv.getIdentifier().equals(canvasUri))
-            .map(canv -> this.copyAttributionInfo(manifest, canv))
-            .findFirst().orElseThrow(ResolvingException::new);
+        .flatMap(seq -> seq.getCanvases().stream())
+        .filter(canv -> canv.getIdentifier().equals(canvasUri))
+        .map(canv -> this.copyAttributionInfo(manifest, canv))
+        .findFirst()
+        .orElseThrow(ResolvingException::new);
   }
 
-  default Range getRange(String manifestId, String rangeUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Range getRange(String manifestId, String rangeUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     return getRange(manifestId, URI.create(rangeUri));
   }
 
-  default Range getRange(String manifestId, URI rangeUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Range getRange(String manifestId, URI rangeUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     Manifest manifest = getManifest(manifestId);
     return manifest.getRanges().stream()
-            .filter(r -> r.getIdentifier().equals(rangeUri))
-            .map(r -> this.copyAttributionInfo(manifest, r))
-            .findFirst().orElseThrow(ResolvingException::new);
+        .filter(r -> r.getIdentifier().equals(rangeUri))
+        .map(r -> this.copyAttributionInfo(manifest, r))
+        .findFirst()
+        .orElseThrow(ResolvingException::new);
   }
 
-  default Sequence getSequence(String manifestId, String sequenceUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Sequence getSequence(String manifestId, String sequenceUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     return getSequence(manifestId, URI.create(sequenceUri));
   }
 
-  default Sequence getSequence(String manifestId, URI sequenceUri) throws ResolvingException, ResourceNotFoundException, InvalidDataException {
+  default Sequence getSequence(String manifestId, URI sequenceUri)
+      throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     Manifest manifest = getManifest(manifestId);
     return manifest.getSequences().stream()
-            .filter(s -> s.getIdentifier().equals(sequenceUri))
-            .map(s -> this.copyAttributionInfo(manifest, s))
-            .findFirst().orElseThrow(ResolvingException::new);
+        .filter(s -> s.getIdentifier().equals(sequenceUri))
+        .map(s -> this.copyAttributionInfo(manifest, s))
+        .findFirst()
+        .orElseThrow(ResolvingException::new);
   }
 
   default <T extends Resource> T copyAttributionInfo(Manifest manifest, T res) {

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiController.java
@@ -36,21 +36,22 @@ public class IIIFPresentationApiController {
   private static final Logger LOGGER = LoggerFactory.getLogger(IIIFPresentationApiController.class);
   public static final String VERSION = "v2";
 
-  @Autowired
-  protected CustomResponseHeaders customResponseHeaders;
+  @Autowired protected CustomResponseHeaders customResponseHeaders;
 
-  @Autowired
-  private PresentationService presentationService;
+  @Autowired private PresentationService presentationService;
 
-  @Autowired
-  private MetricsService metricsService;
+  @Autowired private MetricsService metricsService;
 
-  // We set the header ourselves, since using @CrossOrigin doesn't expose "*", but always sets the requesting domain
+  // We set the header ourselves, since using @CrossOrigin doesn't expose "*", but always sets the
+  // requesting domain
   // @CrossOrigin(allowedHeaders = {"*"}, origins = {"*"})
-  @RequestMapping(value = {"{identifier}/manifest", "{identifier}"}, method = RequestMethod.GET,
-                  produces = "application/json")
+  @RequestMapping(
+      value = {"{identifier}/manifest", "{identifier}"},
+      method = RequestMethod.GET,
+      produces = "application/json")
   @ResponseBody
-  public Manifest getManifest(@PathVariable String identifier, WebRequest request, HttpServletResponse resp)
+  public Manifest getManifest(
+      @PathVariable String identifier, WebRequest request, HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.isInsecure(identifier)) {
       resp.setStatus(400);
@@ -64,18 +65,24 @@ public class IIIFPresentationApiController {
     long generationDuration = System.currentTimeMillis();
     Manifest manifest = presentationService.getManifest(identifier);
     generationDuration = System.currentTimeMillis() - generationDuration;
-    metricsService.increaseCounterWithDurationAndPercentiles("generations", "manifest", generationDuration);
+    metricsService.increaseCounterWithDurationAndPercentiles(
+        "generations", "manifest", generationDuration);
     resp.setDateHeader("Last-Modified", modified);
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationManifest().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationManifest()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     LOGGER.info("Serving manifest for {}", identifier);
     return manifest;
   }
 
-  @RequestMapping(value = {"{identifier}/manifest", "{identifier}"}, method = RequestMethod.HEAD)
+  @RequestMapping(
+      value = {"{identifier}/manifest", "{identifier}"},
+      method = RequestMethod.HEAD)
   public void checkManifest(@PathVariable String identifier, HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException {
     if (UrlRules.isInsecure(identifier)) {
@@ -86,15 +93,24 @@ public class IIIFPresentationApiController {
     resp.setDateHeader("Last-Modified", modDate.toEpochMilli());
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationManifest().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationManifest()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     resp.setStatus(HttpStatus.SC_OK);
   }
 
-  @RequestMapping(value = {"{manifestId}/canvas/{canvasId}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"{manifestId}/canvas/{canvasId}"},
+      method = RequestMethod.GET)
   @ResponseBody
-  public Canvas getCanvas(@PathVariable String manifestId, @PathVariable String canvasId, HttpServletRequest req, HttpServletResponse resp)
+  public Canvas getCanvas(
+      @PathVariable String manifestId,
+      @PathVariable String canvasId,
+      HttpServletRequest req,
+      HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.anyIsInsecure(manifestId, canvasId)) {
       resp.setStatus(400);
@@ -102,15 +118,24 @@ public class IIIFPresentationApiController {
     }
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationManifest().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationManifest()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     return presentationService.getCanvas(manifestId, getOriginalUri(req));
   }
 
-  @RequestMapping(value = {"{manifestId}/range/{rangeId}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"{manifestId}/range/{rangeId}"},
+      method = RequestMethod.GET)
   @ResponseBody
-  public Range getRange(@PathVariable String manifestId, @PathVariable String rangeId, HttpServletRequest req, HttpServletResponse resp)
+  public Range getRange(
+      @PathVariable String manifestId,
+      @PathVariable String rangeId,
+      HttpServletRequest req,
+      HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.anyIsInsecure(manifestId, rangeId)) {
       resp.setStatus(400);
@@ -118,15 +143,24 @@ public class IIIFPresentationApiController {
     }
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationManifest().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationManifest()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     return presentationService.getRange(manifestId, getOriginalUri(req));
   }
 
-  @RequestMapping(value = {"{manifestId}/sequence/{sequenceId}"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"{manifestId}/sequence/{sequenceId}"},
+      method = RequestMethod.GET)
   @ResponseBody
-  public Sequence getSequence(@PathVariable String manifestId, @PathVariable String sequenceId, HttpServletRequest req, HttpServletResponse resp)
+  public Sequence getSequence(
+      @PathVariable String manifestId,
+      @PathVariable String sequenceId,
+      HttpServletRequest req,
+      HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.anyIsInsecure(manifestId, sequenceId)) {
       resp.setStatus(400);
@@ -134,16 +168,22 @@ public class IIIFPresentationApiController {
     }
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationManifest().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationManifest()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     return presentationService.getSequence(manifestId, getOriginalUri(req));
   }
 
-  @RequestMapping(value = {"collection/{identifier}"}, method = {RequestMethod.GET, RequestMethod.HEAD},
-                  produces = "application/json")
+  @RequestMapping(
+      value = {"collection/{identifier}"},
+      method = {RequestMethod.GET, RequestMethod.HEAD},
+      produces = "application/json")
   @ResponseBody
-  public Collection getCollection(@PathVariable String identifier, WebRequest request, HttpServletResponse resp)
+  public Collection getCollection(
+      @PathVariable String identifier, WebRequest request, HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.isInsecure(identifier)) {
       resp.setStatus(400);
@@ -152,9 +192,12 @@ public class IIIFPresentationApiController {
     long modified = presentationService.getCollectionModificationDate(identifier).toEpochMilli();
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationCollection().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationCollection()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
     if (request.checkNotModified(modified)) {
       return null;
     }
@@ -163,9 +206,15 @@ public class IIIFPresentationApiController {
     return collection;
   }
 
-  @GetMapping(value = {"{identifier}/list/{name}/{canvasId}"}, produces = "application/json")
+  @GetMapping(
+      value = {"{identifier}/list/{name}/{canvasId}"},
+      produces = "application/json")
   @ResponseBody
-  public AnnotationList getAnnotationList(@PathVariable String identifier, @PathVariable String name, @PathVariable String canvasId, HttpServletResponse resp)
+  public AnnotationList getAnnotationList(
+      @PathVariable String identifier,
+      @PathVariable String name,
+      @PathVariable String canvasId,
+      HttpServletResponse resp)
       throws ResolvingException, ResourceNotFoundException, InvalidDataException {
     if (UrlRules.anyIsInsecure(identifier, name, canvasId)) {
       resp.setStatus(400);
@@ -173,9 +222,12 @@ public class IIIFPresentationApiController {
     }
     resp.addHeader("Access-Control-Allow-Origin", "*");
 
-    customResponseHeaders.forPresentationAnnotationList().forEach(customResponseHeader -> {
-      resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
-    });
+    customResponseHeaders
+        .forPresentationAnnotationList()
+        .forEach(
+            customResponseHeader -> {
+              resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
+            });
 
     LOGGER.info("Serving annotation list for {}-{}_{}", name, identifier, canvasId);
     return presentationService.getAnnotationList(identifier, name, canvasId);

--- a/src/main/java/de/digitalcollections/iiif/hymir/util/UrlRules.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/util/UrlRules.java
@@ -17,9 +17,9 @@ public class UrlRules {
     }
     String decodedIdentifier = URLDecoder.decode(identifier, StandardCharsets.UTF_8);
     return identifier.contains("..")
-           || decodedIdentifier.contains("..")
-           || identifier.startsWith("/")
-           || decodedIdentifier.startsWith("/");
+        || decodedIdentifier.contains("..")
+        || identifier.startsWith("/")
+        || decodedIdentifier.startsWith("/");
   }
 
   /**
@@ -36,5 +36,4 @@ public class UrlRules {
     }
     return false;
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/hymir/ApplicationTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/ApplicationTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.hymir;
 
+import static org.assertj.core.api.BDDAssertions.then;
+
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,31 +15,29 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.BDDAssertions.then;
-
-/**
- * Basic integration tests for webapp endpoints.
- */
+/** Basic integration tests for webapp endpoints. */
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {Application.class},
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // set random webapp/server port
-@TestPropertySource(properties = {"management.server.port=0", "spring.profiles.active=PROD"}) // set random management port
+@SpringBootTest(
+    classes = {Application.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT) // set random webapp/server port
+@TestPropertySource(
+    properties = {
+      "management.server.port=0",
+      "spring.profiles.active=PROD"
+    }) // set random management port
 public class ApplicationTest {
 
-  @LocalServerPort
-  private int port;
+  @LocalServerPort private int port;
 
-  @LocalManagementPort
-  private int mgt;
+  @LocalManagementPort private int mgt;
 
-  @Autowired
-  private TestRestTemplate testRestTemplate;
+  @Autowired private TestRestTemplate testRestTemplate;
 
   @Test
   public void shouldReturn200WhenSendingRequestToRoot() {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<String> entity = this.testRestTemplate.getForEntity(
-            "http://localhost:" + this.port + "/", String.class);
+    ResponseEntity<String> entity =
+        this.testRestTemplate.getForEntity("http://localhost:" + this.port + "/", String.class);
 
     then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
@@ -45,8 +45,10 @@ public class ApplicationTest {
   @Test
   public void shouldReturn200WhenSendingAuthorizedRequestToSensitiveManagementEndpoint() {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<Map> entity = this.testRestTemplate.withBasicAuth("admin", "secret").getForEntity(
-            "http://localhost:" + this.mgt + "/monitoring/env", Map.class);
+    ResponseEntity<Map> entity =
+        this.testRestTemplate
+            .withBasicAuth("admin", "secret")
+            .getForEntity("http://localhost:" + this.mgt + "/monitoring/env", Map.class);
 
     then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
   }
@@ -54,10 +56,10 @@ public class ApplicationTest {
   @Test
   public void shouldReturn401WhenSendingUnauthorizedRequestToSensitiveManagementEndpoint() {
     @SuppressWarnings("rawtypes")
-    ResponseEntity<Map> entity = this.testRestTemplate.getForEntity(
+    ResponseEntity<Map> entity =
+        this.testRestTemplate.getForEntity(
             "http://localhost:" + this.mgt + "/monitoring/env", Map.class);
 
     then(entity.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/hymir/JsonPathAssert.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/JsonPathAssert.java
@@ -1,7 +1,8 @@
 /**
- * The following class was taken from https://github.com/revinate/assertj-json, which is licensed under MIT.
- * Here we circumwent an assertj-core binary compatibility problem, see https://github.com/joel-costigliola/assertj-core/issues/1317.
- * Latest assertj-json version was compiled with assertj-core in version 3.8.0, that is not compatible with >= 3.11.1.
+ * The following class was taken from https://github.com/revinate/assertj-json, which is licensed
+ * under MIT. Here we circumwent an assertj-core binary compatibility problem, see
+ * https://github.com/joel-costigliola/assertj-core/issues/1317. Latest assertj-json version was
+ * compiled with assertj-core in version 3.8.0, that is not compatible with >= 3.11.1.
  */
 package de.digitalcollections.iiif.hymir;
 
@@ -47,18 +48,19 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
   }
 
   /**
-   * Extracts a JSON array using a JsonPath expression and wrap it in a {@link ListAssert}. This method requires
-   * the JsonPath to be <a href="https://github.com/jayway/JsonPath#jsonprovider-spi">configured with Jackson or
-   * Gson</a>.
+   * Extracts a JSON array using a JsonPath expression and wrap it in a {@link ListAssert}. This
+   * method requires the JsonPath to be <a
+   * href="https://github.com/jayway/JsonPath#jsonprovider-spi">configured with Jackson or Gson</a>.
    *
    * @param path JsonPath to extract the array
    * @param type The type to cast the content of the array, i.e.: {@link String}, {@link Integer}
    * @param <T> The generic type of the type field
    * @return an instance of {@link ListAssert}
    */
-  public <T> AbstractListAssert<?, ? extends List<? extends T>, T, ? extends AbstractAssert<?, T>> jsonPathAsListOf(String path, Class<T> type) {
-    return Assertions.assertThat(actual.read(path, new TypeRef<List<T>>() {
-    }));
+  public <T>
+      AbstractListAssert<?, ? extends List<? extends T>, T, ? extends AbstractAssert<?, T>>
+          jsonPathAsListOf(String path, Class<T> type) {
+    return Assertions.assertThat(actual.read(path, new TypeRef<List<T>>() {}));
   }
 
   /**
@@ -82,8 +84,8 @@ public class JsonPathAssert extends AbstractAssert<JsonPathAssert, DocumentConte
   }
 
   /**
-   * Extracts a any JSON type using a JsonPath expression and wrap it in an {@link ObjectAssert}. Use this method
-   * to check for nulls or to do type checks.
+   * Extracts a any JSON type using a JsonPath expression and wrap it in an {@link ObjectAssert}.
+   * Use this method to check for nulls or to do type checks.
    *
    * @param path JsonPath to extract the type
    * @return an instance of {@link ObjectAssert}

--- a/src/test/java/de/digitalcollections/iiif/hymir/TestConfiguration.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/TestConfiguration.java
@@ -16,9 +16,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-@ComponentScan(basePackages = {
-  "de.digitalcollections.commons.file.config"
-})
+@ComponentScan(basePackages = {"de.digitalcollections.commons.file.config"})
 public class TestConfiguration implements WebMvcConfigurer {
 
   @Bean
@@ -42,24 +40,25 @@ public class TestConfiguration implements WebMvcConfigurer {
   }
 
   public static void setDefaults() {
-    com.jayway.jsonpath.Configuration.setDefaults(new com.jayway.jsonpath.Configuration.Defaults() {
-      private final JsonProvider jsonProvider = new JacksonJsonProvider();
-      private final MappingProvider mappingProvider = new JacksonMappingProvider();
+    com.jayway.jsonpath.Configuration.setDefaults(
+        new com.jayway.jsonpath.Configuration.Defaults() {
+          private final JsonProvider jsonProvider = new JacksonJsonProvider();
+          private final MappingProvider mappingProvider = new JacksonMappingProvider();
 
-      @Override
-      public JsonProvider jsonProvider() {
-        return jsonProvider;
-      }
+          @Override
+          public JsonProvider jsonProvider() {
+            return jsonProvider;
+          }
 
-      @Override
-      public MappingProvider mappingProvider() {
-        return mappingProvider;
-      }
+          @Override
+          public MappingProvider mappingProvider() {
+            return mappingProvider;
+          }
 
-      @Override
-      public Set<Option> options() {
-        return EnumSet.noneOf(Option.class);
-      }
-    });
+          @Override
+          public Set<Option> options() {
+            return EnumSet.noneOf(Option.class);
+          }
+        });
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/hymir/config/CustomResponseHeadersTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/config/CustomResponseHeadersTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.hymir.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.iiif.hymir.Application;
 import de.digitalcollections.iiif.hymir.config.CustomResponseHeaders.ResponseHeader;
 import java.util.List;
@@ -9,18 +11,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-  properties = {"spring.profiles.active=TEST",
-                "spring.config.name=application-test"},
-  classes = {Application.class},
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    properties = {"spring.profiles.active=TEST", "spring.config.name=application-test"},
+    classes = {Application.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class CustomResponseHeadersTest {
 
-  @Autowired
-  private CustomResponseHeaders headers;
+  @Autowired private CustomResponseHeaders headers;
 
   @Test
   public void testCustomResponseHeadersConfiguration() {
@@ -37,5 +35,4 @@ public class CustomResponseHeadersTest {
     assertThat(headers.forPresentationManifest().size()).isEqualTo(3);
     assertThat(headers.forPresentationCollection().size()).isEqualTo(1);
   }
-
 }

--- a/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.iiif.hymir.presentation.frontend;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import de.digitalcollections.iiif.hymir.Application;
 import de.digitalcollections.iiif.hymir.TestConfiguration;
 import de.digitalcollections.iiif.hymir.presentation.business.PresentationServiceImpl;
@@ -14,27 +16,20 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(
-  properties = {"spring.profiles.active=TEST",
-                "spring.config.name=application-test"},
-  classes = {Application.class, TestConfiguration.class},
-  webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+    properties = {"spring.profiles.active=TEST", "spring.config.name=application-test"},
+    classes = {Application.class, TestConfiguration.class},
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class IIIFPresentationApiControllerTest {
 
-  @LocalServerPort
-  private int randomServerPort;
+  @LocalServerPort private int randomServerPort;
 
-  @Autowired
-  protected IIIFPresentationApiController iiifController;
+  @Autowired protected IIIFPresentationApiController iiifController;
 
-  @Autowired
-  protected PresentationServiceImpl presentationService;
+  @Autowired protected PresentationServiceImpl presentationService;
 
-  @Autowired
-  private TestRestTemplate restTemplate;
+  @Autowired private TestRestTemplate restTemplate;
 
   @BeforeAll
   public static void beforeAll() {
@@ -44,13 +39,23 @@ public class IIIFPresentationApiControllerTest {
 
   @Test
   public void testInvalidDataInManifest() {
-    ResponseEntity<String> response = restTemplate.getForEntity("/presentation/" + IIIFPresentationApiController.VERSION + "/manifest-invalid-data/manifest", String.class);
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            "/presentation/"
+                + IIIFPresentationApiController.VERSION
+                + "/manifest-invalid-data/manifest",
+            String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
   }
 
   @Test
   public void testManifest() {
-    ResponseEntity<String> response = restTemplate.getForEntity("/presentation/" + IIIFPresentationApiController.VERSION + "/manifest-valid-data/manifest", String.class);
+    ResponseEntity<String> response =
+        restTemplate.getForEntity(
+            "/presentation/"
+                + IIIFPresentationApiController.VERSION
+                + "/manifest-valid-data/manifest",
+            String.class);
     assertThat(response.getHeaders().get("mani1")).containsExactly("mani-value1");
     assertThat(response.getHeaders().get("mani2")).containsExactly("mani-value2");
   }


### PR DESCRIPTION
This MR replaces checkstyle with a maven-plugin that automatically reformats the code to conform with the Google Java Style Guide during the format execution goal, which is executed during the standard clean install and clean test targets.