### PR TITLE
Bump versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.4.RELEASE</version>
+    <version>2.4.1</version>
   </parent>
 
   <name>DigitalCollections: Hymir IIIF Server</name>
@@ -82,15 +82,15 @@
     <version.dc-commons-server>4.1.1</version.dc-commons-server>
     <version.dc-commons-springboot>4.1.1</version.dc-commons-springboot>
     <version.dc-commons-springmvc>4.1.2</version.dc-commons-springmvc>
-    <version.guava>29.0-jre</version.guava>
-    <version.iiif-apis>0.3.9-SNAPSHOT</version.iiif-apis>
+    <version.guava>30.0-jre</version.guava>
+    <version.iiif-apis>0.3.9</version.iiif-apis>
     <version.imageio-jnr>0.4.4</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
     <version.json-simple>1.1.1</version.json-simple>
-    <version.logstash-logback-encoder>6.4</version.logstash-logback-encoder>
-    <version.spotbugs>4.1.4</version.spotbugs>
+    <version.logstash-logback-encoder>6.5</version.logstash-logback-encoder>
+    <version.spotbugs>4.2.0</version.spotbugs>
     <version.thymeleaf-extras-conditionalcomments>2.1.2.RELEASE</version.thymeleaf-extras-conditionalcomments>
-    <version.twelvemonkeys>3.6</version.twelvemonkeys>
+    <version.twelvemonkeys>3.6.1</version.twelvemonkeys>
     <version.webjar-bootstrap>4.5.3</version.webjar-bootstrap>
     <version.webjar-html5shiv>3.7.3-1</version.webjar-html5shiv>
     <version.webjar-ie10-viewport-bug-workaround>1.0.3</version.webjar-ie10-viewport-bug-workaround>


### PR DESCRIPTION
 spring-boot-starter-parent to 2.4.1
 guava to 30.0-jre
 logstash-logback-encoder to 6.5
 spotbugs to 4.2.0
 twelvemonkeys to 3.6.1
 iiif-apis to 0.3.9