### PR TITLE
Use error message for logging if present

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
@@ -49,7 +49,10 @@ public class ExceptionAdvice {
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(Exception.class)
   public void handleAllOther(Exception exception) {
-    LOGGER.error("exception stack trace", exception);
+    if (exception.getMessage() != null) {
+      LOGGER.error(exception.getMessage(), exception);
+    } else {
+      LOGGER.error("exception stack trace", exception);
+    }
   }
-  // NOP
 }


### PR DESCRIPTION
Use Exception.getMessage() instead of the "exception stack trace" as log message.