### PR TITLE
Remove unused dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <version.dc-commons-server>4.1.1</version.dc-commons-server>
     <version.dc-commons-springboot>4.1.1</version.dc-commons-springboot>
     <version.dc-commons-springmvc>4.1.2</version.dc-commons-springmvc>
-    <version.guava>30.1.1-jre</version.guava>
     <version.iiif-apis>0.3.9</version.iiif-apis>
     <version.imageio-jnr>0.5.1</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
@@ -140,11 +139,6 @@
       <groupId>com.github.spotbugs</groupId>
       <artifactId>spotbugs-annotations</artifactId>
       <version>${version.spotbugs}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${version.guava}</version>
     </dependency>
     <dependency>
       <groupId>com.googlecode.json-simple</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,6 @@
     <versionName>${project.version} manually built by ${user.name} at ${maven.build.timestamp}</versionName>
 
     <version.assertj-json>1.2.0</version.assertj-json>
-    <version.commons-cli>1.4</version.commons-cli>
     <version.dc-commons-file>5.0.1</version.dc-commons-file>
     <version.dc-commons-server>4.1.1</version.dc-commons-server>
     <version.dc-commons-springboot>4.1.1</version.dc-commons-springboot>
@@ -85,7 +84,6 @@
     <version.iiif-apis>0.3.9</version.iiif-apis>
     <version.imageio-jnr>0.5.1</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
-    <version.json-simple>1.1.1</version.json-simple>
     <version.logstash-logback-encoder>6.6</version.logstash-logback-encoder>
     <version.spotbugs>4.2.3</version.spotbugs>
     <version.thymeleaf-extras-conditionalcomments>2.1.2.RELEASE</version.thymeleaf-extras-conditionalcomments>
@@ -141,17 +139,6 @@
       <version>${version.spotbugs}</version>
     </dependency>
     <dependency>
-      <groupId>com.googlecode.json-simple</groupId>
-      <artifactId>json-simple</artifactId>
-      <version>${version.json-simple}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
       <groupId>com.revinate</groupId>
       <artifactId>assertj-json</artifactId>
       <version>${version.assertj-json}</version>
@@ -171,11 +158,6 @@
       <groupId>com.twelvemonkeys.imageio</groupId>
       <artifactId>imageio-tiff</artifactId>
       <version>${version.twelvemonkeys}</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-cli</groupId>
-      <artifactId>commons-cli</artifactId>
-      <version>${version.commons-cli}</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -213,10 +213,6 @@
       <artifactId>thymeleaf-layout-dialect</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Guava was declared as dependency but never actually used. Therefore it can be safely removed.