### PR TITLE
Return status 400 if scaling results in zero height

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ApiError.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ApiError.java
@@ -1,0 +1,26 @@
+package de.digitalcollections.iiif.hymir.frontend;
+
+/**
+ * Response object to communicate the reason an API error occoured.
+ */
+public class ApiError {
+
+  private final String reason;
+
+  /**
+   * Takes the message from an Exception an sets it as the reason for the API failure.
+   * @param exception The exception to take as reason.
+   */
+  public ApiError(Exception exception) {
+    this.reason = exception.getMessage();
+  }
+
+  /**
+   *
+   * @return The reason why the request failed.
+   */
+  public String getReason() {
+    return reason;
+  }
+
+}

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
@@ -2,14 +2,19 @@ package de.digitalcollections.iiif.hymir.frontend;
 
 import de.digitalcollections.iiif.hymir.model.exception.InvalidParametersException;
 import de.digitalcollections.iiif.hymir.model.exception.ResolvingException;
+import de.digitalcollections.iiif.hymir.model.exception.ScalingException;
 import de.digitalcollections.iiif.hymir.model.exception.UnsupportedFormatException;
 import de.digitalcollections.model.api.identifiable.resource.exceptions.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.trace.http.HttpTrace.Response;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice
 public class ExceptionAdvice {
@@ -32,6 +37,18 @@ public class ExceptionAdvice {
   @ExceptionHandler(ResourceNotFoundException.class)
   public void handleResourceNotFoundException(Exception exception) {
     // NOP
+  }
+
+  /**
+   * Sometimes scaling an image can lead to broken dimensions (usually because of rounding to 0).
+   * @param exception The exception to handle
+   * @return An error description for the client
+   */
+  @ExceptionHandler(ScalingException.class)
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ResponseBody
+  protected ApiError handleSolrException(ScalingException exception) {
+    return new ApiError(exception);
   }
 
   @ResponseStatus(value = HttpStatus.UNSUPPORTED_MEDIA_TYPE)

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/api/ImageService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/api/ImageService.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.iiif.hymir.image.business.api;
 
 import de.digitalcollections.iiif.hymir.model.exception.InvalidParametersException;
+import de.digitalcollections.iiif.hymir.model.exception.ScalingException;
 import de.digitalcollections.iiif.hymir.model.exception.UnsupportedFormatException;
 import de.digitalcollections.iiif.model.image.ImageApiProfile;
 import de.digitalcollections.iiif.model.image.ImageApiSelector;
@@ -23,5 +24,5 @@ public interface ImageService {
   void processImage(
       String identifier, ImageApiSelector selector, ImageApiProfile profile, OutputStream os)
       throws InvalidParametersException, UnsupportedOperationException, UnsupportedFormatException,
-          ResourceNotFoundException, IOException;
+      ResourceNotFoundException, IOException, ScalingException;
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
@@ -4,6 +4,7 @@ import de.digitalcollections.commons.springboot.metrics.MetricsService;
 import de.digitalcollections.iiif.hymir.config.CustomResponseHeaders;
 import de.digitalcollections.iiif.hymir.image.business.api.ImageService;
 import de.digitalcollections.iiif.hymir.model.exception.InvalidParametersException;
+import de.digitalcollections.iiif.hymir.model.exception.ScalingException;
 import de.digitalcollections.iiif.hymir.model.exception.UnsupportedFormatException;
 import de.digitalcollections.iiif.hymir.util.UrlRules;
 import de.digitalcollections.iiif.model.image.ImageApiProfile;
@@ -99,7 +100,7 @@ public class IIIFImageApiController {
       HttpServletResponse response,
       WebRequest webRequest)
       throws UnsupportedFormatException, UnsupportedOperationException, IOException,
-          InvalidParametersException, ResourceNotFoundException {
+      InvalidParametersException, ResourceNotFoundException, ScalingException {
     if (UrlRules.isInsecure(identifier)) {
       return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new byte[] {});
     }

--- a/src/main/java/de/digitalcollections/iiif/hymir/model/exception/ScalingException.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/model/exception/ScalingException.java
@@ -1,0 +1,12 @@
+package de.digitalcollections.iiif.hymir.model.exception;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+
+public class ScalingException extends Exception {
+
+  public ScalingException(String message) {
+    super(message);
+  }
+
+}

--- a/src/test/java/de/digitalcollections/iiif/hymir/frontend/ApiErrorTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/frontend/ApiErrorTest.java
@@ -1,0 +1,16 @@
+package de.digitalcollections.iiif.hymir.frontend;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class ApiErrorTest {
+
+  @Test
+  void getReason() {
+    String expected = "expected reason";
+    ApiError apiError = new ApiError(new Exception(expected));
+    assertThat(apiError.getReason()).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
Sometimes scaling would result in a image height or width of 0. In this case the IIIF Image API 2.1.1 specs say a status code 400 should be returned.

Fixes #211 