### PR TITLE
Fix rounding error

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -206,7 +206,7 @@ public class ImageServiceImpl implements ImageService {
   /**
    * Determine parameters for image reading based on the IIIF selector and a given scaling factor *
    */
-  private ImageReadParam getReadParam(
+  static ImageReadParam getReadParam(
       ImageReader reader, ImageApiSelector selector, double decodeScaleFactor)
       throws IOException, InvalidParametersException {
     ImageReadParam readParam = reader.getDefaultReadParam();
@@ -222,10 +222,10 @@ public class ImageServiceImpl implements ImageService {
     // image size, hence the conversion
     Rectangle decodeRegion =
         new Rectangle(
-            (int) Math.ceil(targetRegion.getX() * decodeScaleFactor),
-            (int) Math.ceil(targetRegion.getY() * decodeScaleFactor),
-            (int) Math.ceil(targetRegion.getWidth() * decodeScaleFactor),
-            (int) Math.ceil(targetRegion.getHeight() * decodeScaleFactor));
+            (int) Math.round(targetRegion.getX() * decodeScaleFactor),
+            (int) Math.round(targetRegion.getY() * decodeScaleFactor),
+            (int) Math.round(targetRegion.getWidth() * decodeScaleFactor),
+            (int) Math.round(targetRegion.getHeight() * decodeScaleFactor));
     readParam.setSourceRegion(decodeRegion);
     // TurboJpegImageReader can rotate during decoding
     if (selector.getRotation().getRotation() != 0 && reader instanceof TurboJpegImageReader) {

--- a/src/test/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImplTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImplTest.java
@@ -1,19 +1,32 @@
 package de.digitalcollections.iiif.hymir.image.business;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import de.digitalcollections.iiif.hymir.model.exception.InvalidParametersException;
+import de.digitalcollections.iiif.model.image.ImageApiProfile.Format;
+import de.digitalcollections.iiif.model.image.ImageApiProfile.Quality;
+import de.digitalcollections.iiif.model.image.ImageApiSelector;
+import de.digitalcollections.iiif.model.image.ResolvingException;
+import de.digitalcollections.turbojpeg.imageio.TurboJpegImageReadParam;
+import java.awt.Dimension;
+import java.awt.Rectangle;
 import java.awt.image.BufferedImage;
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import javax.imageio.ImageIO;
+import javax.imageio.ImageReadParam;
+import javax.imageio.ImageReader;
 import org.junit.jupiter.api.Test;
 import org.springframework.util.ResourceUtils;
 
 public class ImageServiceImplTest {
 
   @Test
-  public void testContainsAlphaChannel() throws FileNotFoundException, IOException {
+  public void testContainsAlphaChannel() throws IOException {
     File file = ResourceUtils.getFile("classpath:test-alpha-transparency-yes.png");
     BufferedImage image = ImageIO.read(file);
     boolean expResult = true;
@@ -26,4 +39,28 @@ public class ImageServiceImplTest {
     result = ImageServiceImpl.containsAlphaChannel(image);
     assertEquals(expResult, result);
   }
+
+  @Test
+  void getReadParamShouldRoundCorrectly()
+      throws ResolvingException, InvalidParametersException, IOException {
+    ImageReader reader = mock(ImageReader.class);
+    when(reader.getDefaultReadParam()).thenAnswer(invocation -> new TurboJpegImageReadParam());
+    Dimension nativeDimensions = new Dimension(2806, 3952);
+    when(reader.getWidth(eq(0))).thenReturn(nativeDimensions.width);
+    when(reader.getHeight(eq(0))).thenReturn(nativeDimensions.height);
+
+    String identifier = "bsb00041016_00002";
+    ImageApiSelector selector = new ImageApiSelector();
+    selector.setIdentifier(identifier);
+    selector.setRegion("full");
+    selector.setSize("142,");
+    selector.setRotation("90");
+    selector.setQuality(Quality.DEFAULT);
+    selector.setFormat(Format.JPG);
+
+    ImageReadParam actual = ImageServiceImpl.getReadParam(reader, selector, 0.12508909479686386);
+    assertThat(actual.getSourceRegion()).isEqualTo(new Rectangle(0, 0, 351, 494));
+  }
+
+
 }


### PR DESCRIPTION
In certain cases, the rounding is off by one pixel because Math.ceil is used. If in these cases also rotation is applied and the image happens to be processed by libturbojpeg, then this sends down the whole processing a wrong path, ultimately resulting in an exception that the requested area would exceed the image itself.

Fixes #212 