### PR TITLE
Prepare release 5.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>iiif-server-hymir</artifactId>
-  <version>5.0.5-SNAPSHOT</version>
+  <version>5.0.5</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/dbmdz/iiif-server-hymir</url>
@@ -84,7 +84,7 @@
     <version.dc-commons-springmvc>4.1.2</version.dc-commons-springmvc>
     <version.guava>30.1.1-jre</version.guava>
     <version.iiif-apis>0.3.9</version.iiif-apis>
-    <version.imageio-jnr>0.5.1</version.imageio-jnr>
+    <version.imageio-jnr>0.6.0</version.imageio-jnr>
     <version.imgscalr-lib>4.2</version.imgscalr-lib>
     <version.json-simple>1.1.1</version.json-simple>
     <version.logstash-logback-encoder>6.6</version.logstash-logback-encoder>


### PR DESCRIPTION
PR updates version of `image-jnr` plugin to the recently released 0.6.0 version and also bumps repo version to 5.0.5 🎉