### PR TITLE
Fix internal server error for floating point values

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
@@ -126,7 +126,7 @@ public class IIIFImageApiController {
       if (quality.equals("native")) {
         quality = "default";
       }
-    } catch (ResolvingException e) {
+    } catch (ResolvingException | NumberFormatException e) {
       throw new InvalidParametersException(e);
     }
 


### PR DESCRIPTION
Hymir only supports full pixels. Requests with floating point numbers should therefore return Bad Request instead of Internal Server Error.