### PR TITLE
Fix server error for invalid quality parameter

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/frontend/IIIFImageApiController.java
@@ -130,7 +130,11 @@ public class IIIFImageApiController {
       throw new InvalidParametersException(e);
     }
 
-    selector.setQuality(ImageApiProfile.Quality.valueOf(quality.toUpperCase()));
+    try {
+      selector.setQuality(ImageApiProfile.Quality.valueOf(quality.toUpperCase()));
+    } catch (IllegalArgumentException e) {
+      throw new InvalidParametersException(e);
+    }
 
     try {
       selector.setFormat(ImageApiProfile.Format.valueOf(format.toUpperCase()));


### PR DESCRIPTION
```http
GET http://localhost:9000/image/v2/bsb10997265_00132/full/full/0/info.jpg
```
should return status code 400 as `info` is an invalid quality level, but did give an internal server error.