### PR TITLE
Ensure a HTTP 500 is returned in case of low-level I/O errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>iiif-server-hymir</artifactId>
-  <version>5.1.2-SNAPSHOT</version>
+  <version>5.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/dbmdz/iiif-server-hymir</url>
@@ -78,7 +78,7 @@
 
     <version.assertj-json>1.2.0</version.assertj-json>
     <version.commons-cli>1.4</version.commons-cli>
-    <version.dc-commons-file>5.1.0</version.dc-commons-file>
+    <version.dc-commons-file>5.2.0-SNAPSHOT</version.dc-commons-file>
     <version.dc-commons-server>4.1.1</version.dc-commons-server>
     <version.dc-commons-springboot>4.1.1</version.dc-commons-springboot>
     <version.dc-commons-springmvc>4.1.2</version.dc-commons-springmvc>

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -1,6 +1,7 @@
 package de.digitalcollections.iiif.hymir.image.business;
 
 import com.google.common.collect.Streams;
+import de.digitalcollections.commons.file.backend.FileSystemResourceIOException;
 import de.digitalcollections.commons.file.business.api.FileResourceService;
 import de.digitalcollections.iiif.hymir.image.business.api.ImageSecurityService;
 import de.digitalcollections.iiif.hymir.image.business.api.ImageService;
@@ -165,13 +166,8 @@ public class ImageServiceImpl implements ImageService {
         && !imageSecurityService.isAccessAllowed(identifier, currentRequest)) {
       throw new ResourceNotFoundException();
     }
-    FileResource fileResource;
     try {
-      fileResource = fileResourceService.find(identifier, MimeType.MIME_IMAGE);
-    } catch (ResourceIOException e) {
-      throw new ResourceNotFoundException();
-    }
-    try {
+      FileResource fileResource = fileResourceService.find(identifier, MimeType.MIME_IMAGE);
       ImageInputStream iis =
           ImageIO.createImageInputStream(fileResourceService.getInputStream(fileResource));
       ImageReader reader =
@@ -180,6 +176,8 @@ public class ImageServiceImpl implements ImageService {
               .orElseThrow(UnsupportedFormatException::new);
       reader.setInput(iis);
       return reader;
+    } catch (FileSystemResourceIOException e) {
+      throw new IOException(e);
     } catch (ResourceIOException e) {
       throw new ResourceNotFoundException();
     }

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package de.digitalcollections.iiif.hymir.presentation.backend;
 
+import de.digitalcollections.commons.file.backend.FileSystemResourceIOException;
 import de.digitalcollections.commons.file.business.api.FileResourceService;
 import de.digitalcollections.iiif.hymir.model.exception.InvalidDataException;
 import de.digitalcollections.iiif.hymir.model.exception.ResolvingException;
@@ -42,12 +43,19 @@ public class PresentationRepositoryImpl implements PresentationRepository {
     FileResource resource;
     try {
       resource = fileResourceService.find(annotationListName, MimeType.MIME_APPLICATION_JSON);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
       LOGGER.error("Error getting annotation list for name {}", annotationListName, ex);
       throw new ResolvingException("No annotation list for name " + annotationListName);
     }
     try {
       return objectMapper.readValue(getResourceJson(resource), AnnotationList.class);
+    } catch (FileSystemResourceIOException e) {
+      // See comment above
+      throw new RuntimeException(e);
     } catch (IOException ex) {
       LOGGER.error("Could not retrieve annotation list {}", annotationListName, ex);
       throw new InvalidDataException(
@@ -63,12 +71,20 @@ public class PresentationRepositoryImpl implements PresentationRepository {
     FileResource resource;
     try {
       resource = fileResourceService.find(collectionName, MimeType.MIME_APPLICATION_JSON);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
       LOGGER.error("Error getting manifest for collection {}", name, ex);
       throw new ResolvingException("No collection for name " + name);
     }
     try {
       return objectMapper.readValue(getResourceJson(resource), Collection.class);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (IOException ex) {
       LOGGER.info("Could not retrieve collection {}", collectionName, ex);
       throw new InvalidDataException(
@@ -82,12 +98,20 @@ public class PresentationRepositoryImpl implements PresentationRepository {
     FileResource resource;
     try {
       resource = fileResourceService.find(identifier, MimeType.MIME_APPLICATION_JSON);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
       LOGGER.error("Error getting manifest for identifier {}", identifier, ex);
       throw new ResolvingException("No manifest for identifier " + identifier);
     }
     try {
       return objectMapper.readValue(getResourceJson(resource), Manifest.class);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (IOException ex) {
       LOGGER.error("Manifest {} can not be parsed", identifier, ex);
       throw new InvalidDataException("Manifest " + identifier + " can not be parsed", ex);
@@ -111,6 +135,10 @@ public class PresentationRepositoryImpl implements PresentationRepository {
     try {
       FileResource resource = fileResourceService.find(identifier, MimeType.MIME_APPLICATION_JSON);
       return resource.getLastModified().toInstant(ZoneOffset.UTC);
+    } catch (FileSystemResourceIOException e) {
+      // We have to throw a RTE since we don't want to break with the API, but still
+      // have a different error handling path than Resolving/InvalidData.
+      throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
       LOGGER.error(
           "Error getting resource for identifier '{}', message '{}'", identifier, ex.getMessage());


### PR DESCRIPTION
This uses the new `FileSystemResourceIOException` from `dc-commons-file` to ensure that a HTTP 500 is returned when we encounter a low-level I/O exception while retrieving resources.
Previously we'd return a 404 in these cases.