### PR TITLE
Fix off-by-one error when decoding scaled down full-area image

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
   <groupId>de.digitalcollections</groupId>
   <artifactId>iiif-server-hymir</artifactId>
-  <version>5.1.2</version>
+  <version>5.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <url>https://github.com/dbmdz/iiif-server-hymir</url>

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -217,7 +217,7 @@ public class ImageServiceImpl implements ImageService {
   }
 
   /**
-   * Determine parameters for image reading based on the IIIF selector and a given scaling factor *
+   * Determine parameters for image reading based on the IIIF selector the image index to be decoded
    */
   static ImageReadParam getReadParam(ImageReader reader, ImageApiSelector selector, int decodeIdx)
       throws IOException, InvalidParametersException {

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -219,11 +219,13 @@ public class ImageServiceImpl implements ImageService {
   /**
    * Determine parameters for image reading based on the IIIF selector and a given scaling factor *
    */
-  static ImageReadParam getReadParam(
-      ImageReader reader, ImageApiSelector selector, double decodeScaleFactor)
+  static ImageReadParam getReadParam(ImageReader reader, ImageApiSelector selector, int decodeIdx)
       throws IOException, InvalidParametersException {
     ImageReadParam readParam = reader.getDefaultReadParam();
     Dimension nativeDimensions = new Dimension(reader.getWidth(0), reader.getHeight(0));
+    Dimension decodeDimensions =
+        new Dimension(reader.getWidth(decodeIdx), reader.getHeight(decodeIdx));
+    double decodeScaleFactor = decodeDimensions.getWidth() / nativeDimensions.getWidth();
     Rectangle targetRegion;
     try {
       targetRegion = selector.getRegion().resolve(nativeDimensions);
@@ -235,10 +237,16 @@ public class ImageServiceImpl implements ImageService {
     // image size, hence the conversion
     Rectangle decodeRegion =
         new Rectangle(
-            (int) Math.round(targetRegion.getX() * decodeScaleFactor),
-            (int) Math.round(targetRegion.getY() * decodeScaleFactor),
-            (int) Math.round(targetRegion.getWidth() * decodeScaleFactor),
-            (int) Math.round(targetRegion.getHeight() * decodeScaleFactor));
+            Math.min(
+                (int) Math.round(targetRegion.getX() * decodeScaleFactor), decodeDimensions.width),
+            Math.min(
+                (int) Math.round(targetRegion.getY() * decodeScaleFactor), decodeDimensions.height),
+            Math.min(
+                (int) Math.round(targetRegion.getWidth() * decodeScaleFactor),
+                decodeDimensions.width),
+            Math.min(
+                (int) Math.round(targetRegion.getHeight() * decodeScaleFactor),
+                decodeDimensions.height));
     readParam.setSourceRegion(decodeRegion);
     // TurboJpegImageReader can rotate during decoding
     if (selector.getRotation().getRotation() != 0 && reader instanceof TurboJpegImageReader) {
@@ -291,7 +299,7 @@ public class ImageServiceImpl implements ImageService {
           imageIndex = idx;
         }
       }
-      ImageReadParam readParam = getReadParam(reader, selector, decodeScaleFactor);
+      ImageReadParam readParam = getReadParam(reader, selector, imageIndex);
       int rotation = (int) selector.getRotation().getRotation();
       if (readParam instanceof TurboJpegImageReadParam
           && ((TurboJpegImageReadParam) readParam).getRotationDegree() != 0) {

--- a/src/test/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImplTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImplTest.java
@@ -65,6 +65,9 @@ public class ImageServiceImplTest {
     Dimension nativeDimensions = new Dimension(2806, 3952);
     when(reader.getWidth(eq(0))).thenReturn(nativeDimensions.width);
     when(reader.getHeight(eq(0))).thenReturn(nativeDimensions.height);
+    double decodeScaleFactor = 0.12508909479686386;
+    when(reader.getWidth(eq(13))).thenReturn((int) (decodeScaleFactor * nativeDimensions.width));
+    when(reader.getHeight(eq(13))).thenReturn((int) (decodeScaleFactor * nativeDimensions.height));
 
     String identifier = "bsb00041016_00002";
     ImageApiSelector selector = new ImageApiSelector();
@@ -75,7 +78,7 @@ public class ImageServiceImplTest {
     selector.setQuality(Quality.DEFAULT);
     selector.setFormat(Format.JPG);
 
-    ImageReadParam actual = ImageServiceImpl.getReadParam(reader, selector, 0.12508909479686386);
+    ImageReadParam actual = ImageServiceImpl.getReadParam(reader, selector, 13);
     assertThat(actual.getSourceRegion()).isEqualTo(new Rectangle(0, 0, 351, 494));
   }
 


### PR DESCRIPTION
This PR ensures that the decoded, scaled-down version is actually within the image bounds. Previously we'd frequently run into a off-by-one situation due to a rounding error, this is now fixed.