### PR TITLE
Another fix for another off-by-one error...

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -238,14 +238,14 @@ public class ImageServiceImpl implements ImageService {
     Rectangle decodeRegion =
         new Rectangle(
             Math.min(
-                (int) Math.round(targetRegion.getX() * decodeScaleFactor), decodeDimensions.width),
+                (int) Math.floor(targetRegion.getX() * decodeScaleFactor), decodeDimensions.width),
             Math.min(
-                (int) Math.round(targetRegion.getY() * decodeScaleFactor), decodeDimensions.height),
+                (int) Math.floor(targetRegion.getY() * decodeScaleFactor), decodeDimensions.height),
             Math.min(
-                (int) Math.round(targetRegion.getWidth() * decodeScaleFactor),
+                (int) Math.ceil(targetRegion.getWidth() * decodeScaleFactor),
                 decodeDimensions.width),
             Math.min(
-                (int) Math.round(targetRegion.getHeight() * decodeScaleFactor),
+                (int) Math.ceil(targetRegion.getHeight() * decodeScaleFactor),
                 decodeDimensions.height));
     readParam.setSourceRegion(decodeRegion);
     // TurboJpegImageReader can rotate during decoding


### PR DESCRIPTION
This changes the rounding logic for scaling during decoding so that we always expand the area to fit integral pixel values (before we used round, so we'd expand/contract depending on the scaled value). This avoids a corner case where the OpenJPEG decoder misbehaves and triggers a warning.