### PR TITLE
Tweak logging, mark some deprecations

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendImage.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/config/SpringConfigBackendImage.java
@@ -19,32 +19,32 @@ import org.springframework.context.annotation.Import;
 @Import(SpringConfigCommonsFile.class)
 public class SpringConfigBackendImage {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SpringConfigBackendImage.class);
+  private static final Logger log = LoggerFactory.getLogger(SpringConfigBackendImage.class);
 
   static {
     ImageIO.setUseCache(false); // Use Heap memory for caching instead of disk
 
     deregisterSunImageSpis();
     String[] readerMimeTypes = ImageIO.getReaderMIMETypes();
-    LOGGER.info("ImageIO supported formats (reader): {}", String.join(",", readerMimeTypes));
+    log.debug("ImageIO supported formats (reader): {}", String.join(",", readerMimeTypes));
     for (String mimeType : readerMimeTypes) {
       Iterator<ImageReader> imageReaders = ImageIO.getImageReadersByMIMEType(mimeType);
-      for (Iterator iterator = imageReaders; iterator.hasNext(); ) {
-        ImageReader imageReader = (ImageReader) iterator.next();
+      while (imageReaders.hasNext()) {
+        ImageReader imageReader = imageReaders.next();
         if (imageReader != null) {
-          LOGGER.info("ImageReader: {} {}", mimeType, imageReader.getClass().toString());
+          log.debug("ImageReader: {} {}", mimeType, imageReader.getClass().toString());
         }
       }
     }
 
     String[] writerMimeTypes = ImageIO.getWriterMIMETypes();
-    LOGGER.info("ImageIO supported formats (writer): {}", String.join(",", writerMimeTypes));
+    log.debug("ImageIO supported formats (writer): {}", String.join(",", writerMimeTypes));
     for (String writerMimeType : writerMimeTypes) {
       Iterator<ImageWriter> imageWriters = ImageIO.getImageWritersByMIMEType(writerMimeType);
-      for (Iterator iterator = imageWriters; iterator.hasNext(); ) {
-        ImageWriter imageWriter = (ImageWriter) iterator.next();
+      while (imageWriters.hasNext()) {
+        ImageWriter imageWriter = imageWriters.next();
         if (imageWriter != null) {
-          LOGGER.info("ImageWriter: {} {}", writerMimeType, imageWriter.getClass().toString());
+          log.debug("ImageWriter: {} {}", writerMimeType, imageWriter.getClass().toString());
         }
       }
     }
@@ -54,13 +54,11 @@ public class SpringConfigBackendImage {
   private static void deregisterSunImageSpis() {
     IIORegistry registry = IIORegistry.getDefaultInstance();
 
-    // We need to disable using the com.sun.imageio.* classes for tiff and jpeg due to strange
-    // runtime bugs.
-    // But we can just rely on the TwelveMonkeys imageio packages 🎉
-    // gif and png support is not provided by TwelveMonkeys
-    // (https://github.com/haraldk/TwelveMonkeys/issues/137)
-    // so we do not need to disable PNGImage{Reader,Writer}Spi and GIFImage{Reader, Writer}Spi for
-    // the com.sun.imageio.* classes here.
+    // We need to disable usage of the com.sun.imageio.* classes for TIFF, JPEG and BMP due to
+    // strange runtime bugs. Fortunately, the TwelveMonkeys imageio packages for those formats
+    // work 🎉
+    // We can't block all com.sun.imageio.* SPIs, since GIF and PNG support is not provided by
+    // TwelveMonkeys (https://github.com/haraldk/TwelveMonkeys/issues/137).
     Set<String> spis =
         new HashSet<>(
             Arrays.asList(
@@ -75,7 +73,7 @@ public class SpringConfigBackendImage {
         Object spiProvider = registry.getServiceProviderByClass(Class.forName(spi));
         registry.deregisterServiceProvider(spiProvider);
       } catch (ClassNotFoundException e) {
-        LOGGER.debug(e.getMessage());
+        log.debug(e.getMessage());
       }
     }
   }

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @ControllerAdvice
 public class ExceptionAdvice {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ExceptionAdvice.class);
+  private static final Logger log = LoggerFactory.getLogger(ExceptionAdvice.class);
 
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
   @ExceptionHandler(InvalidParametersException.class)
@@ -65,9 +65,9 @@ public class ExceptionAdvice {
   @ExceptionHandler(Exception.class)
   public void handleAllOther(Exception exception) {
     if (exception.getMessage() != null) {
-      LOGGER.error(exception.getMessage(), exception);
+      log.error(exception.getMessage(), exception);
     } else {
-      LOGGER.error("exception stack trace", exception);
+      log.error("Unhandled exception during request handling", exception);
     }
   }
 }

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExtendedViewController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExtendedViewController.java
@@ -23,10 +23,11 @@ import org.springframework.web.bind.annotation.RequestMethod;
  *
  * <p>Provides direct access to viewer for external call. Can be overwritten with custom behaviour.
  */
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 @Controller
 public class ExtendedViewController {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ExtendedViewController.class);
+  private static final Logger log = LoggerFactory.getLogger(ExtendedViewController.class);
 
   @Autowired private PresentationService presentationService;
 
@@ -72,16 +73,16 @@ public class ExtendedViewController {
 
     try {
       presentationService.getCanvas(objectIdentifier, canvasId);
-      LOGGER.info("Serving Canvas for {}", canvasId);
+      log.info("Serving Canvas for {}", canvasId);
 
       model.addAttribute("manifestId", manifestId);
       model.addAttribute("canvasId", canvasId);
 
     } catch (ResolvingException e) {
-      LOGGER.info("Did not find canvas for {}", canvasId);
+      log.info("Did not find canvas for {}", canvasId);
       throw e;
     } catch (InvalidDataException e) {
-      LOGGER.error("Bad data for {}", objectIdentifier);
+      log.error("Bad data for {}", objectIdentifier);
       throw e;
     } finally {
       MDC.clear();

--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ViewController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ViewController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 
 /** Controller for serving different view pages. */
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 @Controller
 public class ViewController {
 

--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -41,16 +41,12 @@ import javax.imageio.stream.ImageInputStream;
 import javax.imageio.stream.ImageOutputStream;
 import javax.servlet.http.HttpServletRequest;
 import org.imgscalr.Scalr;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ImageServiceImpl implements ImageService {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ImageServiceImpl.class);
 
   // FIXME: Yes, this is incredibly nasty and violates "separation of concerns", but it's the
   //        only way to implement ACL based on user-supplied data without refactoring a significant
@@ -418,10 +414,8 @@ public class ImageServiceImpl implements ImageService {
     DecodedImage decodedImage = readImage(identifier, selector, profile);
 
     boolean containsAlphaChannel = containsAlphaChannel(decodedImage.img);
-    LOGGER.debug("image contains alpha channel: " + containsAlphaChannel);
     if (containsAlphaChannel) {
       int type = decodedImage.img.getType();
-      LOGGER.debug("image is of type: " + type);
       if (BufferedImage.TYPE_INT_ARGB != type) {
         // make sure to preserve transparency (e.g. of PNGs)
         // see https://github.com/rkalla/imgscalr section "Working with GIFs"

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/PresentationRepositoryImpl.java
@@ -27,10 +27,12 @@ import org.springframework.stereotype.Repository;
  * Manifest instance.
  */
 @Repository
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 public class PresentationRepositoryImpl implements PresentationRepository {
 
   private static final String COLLECTION_PREFIX = "collection-";
-  private static final Logger LOGGER = LoggerFactory.getLogger(PresentationRepositoryImpl.class);
+
+  private static final Logger log = LoggerFactory.getLogger(PresentationRepositoryImpl.class);
 
   @Autowired private IiifObjectMapper objectMapper;
 
@@ -48,7 +50,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
-      LOGGER.error("Error getting annotation list for name {}", annotationListName, ex);
+      log.error("Error getting annotation list for name {}", annotationListName, ex);
       throw new ResolvingException("No annotation list for name " + annotationListName);
     }
     try {
@@ -57,7 +59,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // See comment above
       throw new RuntimeException(e);
     } catch (IOException ex) {
-      LOGGER.error("Could not retrieve annotation list {}", annotationListName, ex);
+      log.error("Could not retrieve annotation list {}", annotationListName, ex);
       throw new InvalidDataException(
           "Annotation list " + annotationListName + " can not be parsed", ex);
     }
@@ -76,7 +78,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
-      LOGGER.error("Error getting manifest for collection {}", name, ex);
+      log.error("Error getting manifest for collection {}", name, ex);
       throw new ResolvingException("No collection for name " + name);
     }
     try {
@@ -86,7 +88,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (IOException ex) {
-      LOGGER.info("Could not retrieve collection {}", collectionName, ex);
+      log.info("Could not retrieve collection {}", collectionName, ex);
       throw new InvalidDataException(
           "Collection for name " + collectionName + " can not be parsed", ex);
     }
@@ -103,7 +105,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
-      LOGGER.error("Error getting manifest for identifier {}", identifier, ex);
+      log.error("Error getting manifest for identifier {}", identifier, ex);
       throw new ResolvingException("No manifest for identifier " + identifier);
     }
     try {
@@ -113,7 +115,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (IOException ex) {
-      LOGGER.error("Manifest {} can not be parsed", identifier, ex);
+      log.error("Manifest {} can not be parsed", identifier, ex);
       throw new InvalidDataException("Manifest " + identifier + " can not be parsed", ex);
     }
   }
@@ -140,7 +142,7 @@ public class PresentationRepositoryImpl implements PresentationRepository {
       // have a different error handling path than Resolving/InvalidData.
       throw new RuntimeException(e);
     } catch (ResourceIOException ex) {
-      LOGGER.error(
+      log.error(
           "Error getting resource for identifier '{}', message '{}'", identifier, ex.getMessage());
       throw new ResolvingException("No manifest for identifier " + identifier);
     }

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/api/PresentationRepository.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/backend/api/PresentationRepository.java
@@ -9,6 +9,7 @@ import de.digitalcollections.model.exception.ResourceNotFoundException;
 import java.time.Instant;
 
 /** Interface to be implemented by project/user of this library. */
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 public interface PresentationRepository {
 
   /**

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/PresentationServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/PresentationServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 public class PresentationServiceImpl implements PresentationService {
 
   private final PresentationRepository presentationRepository;

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationSecurityService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationSecurityService.java
@@ -4,6 +4,7 @@ import javax.servlet.http.HttpServletRequest;
 
 /** Service responsible for deciding if object (identified by identifier) is accessible. */
 public interface PresentationSecurityService {
+  @Deprecated(forRemoval = true)  // Will be gone with the next major version
 
   boolean isAccessAllowed(String identifier);
 

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationService.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/business/api/PresentationService.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.time.Instant;
 
 /** Service for IIIF Presentation API functionality. */
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 public interface PresentationService {
 
   /**

--- a/src/main/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiController.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiController.java
@@ -17,8 +17,6 @@ import java.net.URI;
 import java.time.Instant;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,9 +28,9 @@ import org.springframework.web.context.request.WebRequest;
 
 @Controller
 @RequestMapping("${custom.iiif.presentation.urlPrefix:/presentation/v2}")
+@Deprecated(forRemoval = true)  // Will be gone with the next major version
 public class IIIFPresentationApiController {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(IIIFPresentationApiController.class);
   public static final String VERSION = "v2";
 
   @Autowired protected CustomResponseHeaders customResponseHeaders;
@@ -75,7 +73,6 @@ public class IIIFPresentationApiController {
             customResponseHeader -> {
               resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
             });
-    LOGGER.info("Serving manifest for {}", identifier);
     return manifest;
   }
 
@@ -201,7 +198,6 @@ public class IIIFPresentationApiController {
       return null;
     }
     Collection collection = presentationService.getCollection(identifier);
-    LOGGER.info("Serving collection for {}", identifier);
     return collection;
   }
 
@@ -228,7 +224,6 @@ public class IIIFPresentationApiController {
               resp.setHeader(customResponseHeader.getName(), customResponseHeader.getValue());
             });
 
-    LOGGER.info("Serving annotation list for {}-{}_{}", name, identifier, canvasId);
     return presentationService.getAnnotationList(identifier, name, canvasId);
   }
 


### PR DESCRIPTION
- Set logger name to `log` (the logger is not a classical constant, so `LOGGER` doesn't really fit)
- Reduce verbosity of INFO loglevel
- Mark Presentation API endpoints and associated components as deprecated and slated for removal in the next major version