### PR TITLE
Fix recording of metrics.

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/image/business/ImageServiceImpl.java
@@ -479,7 +479,11 @@ public class ImageServiceImpl implements ImageService {
     ImageOutputStream ios = ImageIO.createImageOutputStream(os);
     writer.setOutput(ios);
     writer.write(outImg);
-    metrics.endImageOp(encodeMetricKey, ImageDataOp.ENCODE, decodedImage.getPixelSize());
+    metrics.endImageOp(
+        encodeMetricKey,
+        ImageDataOp.ENCODE,
+        writer.getOriginatingProvider().getFormatNames()[0].toLowerCase(Locale.ROOT),
+        decodedImage.getPixelSize());
     writer.dispose();
     ios.flush();
   }


### PR DESCRIPTION
- I misunderstood the Micrometer API, it does not seem to allow for a
  varying set of tags, once a metric has been defined with a given set
  of tags, any subsequent metrics with the same id, but with a different
  set of tags, will be **silently dropped** as far as I  can tell. To
  avoid this, the code is changed so that we always operate with the
  same two tags on all image processing metrics, `format` (`none` if not
  applicable) and `op`.
- Add missing format to `op=encode` metrics