### PR TITLE
Remove mention of BMP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ Hymir is a Java based IIIF Server. It is based on our [IIIF API Java Libraries](
 |  JPEG2000 |   [x]    |   [ ]   |   libopenjp2 (>= 2.3 recommended)          |            |
 |    TIFF   |   [x]    |   [x]   |                                            |            |
 |    PNG    |   [x]    |   [x]   |                                            | Due to possible transparency (alpha channel) in PNG it is not possible to use a PNG source file and deliver it as JPG. PNG delivered as PNG is possible. |
-|    BMP    |   [x]    |   [x]   |                                            |            |
 |    GIF    |   [x]    |   [x]   |                                            |            |
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -127,11 +127,6 @@
     </dependency>
     <dependency>
       <groupId>com.twelvemonkeys.imageio</groupId>
-      <artifactId>imageio-bmp</artifactId>
-      <version>3.8.3</version>
-    </dependency>
-    <dependency>
-      <groupId>com.twelvemonkeys.imageio</groupId>
       <artifactId>imageio-jpeg</artifactId>
       <version>3.8.3</version>
     </dependency>


### PR DESCRIPTION
Hi,

this PR removes the mention of BMP support.

It never worked (due to e.g. missing BMP in `iiif-apis` format enum, see [here](https://github.com/dbmdz/iiif-apis/blob/main/src/main/java/de/digitalcollections/iiif/model/image/ImageApiProfile.java#L31) and it is unclear where to add (`LEVEL_ZERO`?), because BMP is not mentioned in the IIIF specs, see supported formats [here](https://iiif.io/api/image/2.1/#format).