### PR TITLE
pom: bump version of imageio library (to 0.6.4 release)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,12 @@
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-turbojpeg</artifactId>
-      <version>0.6.4-SNAPSHOT</version>
+      <version>0.6.4</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-openjpeg</artifactId>
-      <version>0.6.4-SNAPSHOT</version>
+      <version>0.6.4</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.iiif</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,12 @@
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-turbojpeg</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-openjpeg</artifactId>
-      <version>0.6.3</version>
+      <version>0.6.4-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.iiif</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,12 @@
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-turbojpeg</artifactId>
-      <version>0.6.2</version>
+      <version>0.6.3</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-openjpeg</artifactId>
-      <version>0.6.2</version>
+      <version>0.6.3</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.iiif</groupId>


### PR DESCRIPTION
Hi,

this PR bumps version of imageio library (`turbojpeg` and `openjpeg`) to latest 0.6.4 release.