### PR TITLE
pom: Bump version of dc-commons-file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>de.digitalcollections.commons</groupId>
       <artifactId>dc-commons-file</artifactId>
-      <version>6.0.1-SNAPSHOT</version>
+      <version>6.0.1</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>de.digitalcollections.commons</groupId>
       <artifactId>dc-commons-file</artifactId>
-      <version>6.0.0</version>
+      <version>6.0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.commons</groupId>


### PR DESCRIPTION
Hi,

this PR updates the `dc-commons-file` dependency to latest 6.0.1 release (needed for bugfix, see https://github.com/dbmdz/digitalcollections-commons/pull/871).