### PR TITLE
pom: use latest stable release of ImageIO library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,12 @@
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-turbojpeg</artifactId>
-      <version>0.6.4</version>
+      <version>0.6.5</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-openjpeg</artifactId>
-      <version>0.6.4</version>
+      <version>0.6.5</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.iiif</groupId>


### PR DESCRIPTION
Hi,

this PR updates the ImageIO version to use latest release (with `TJSAMP_411` fix, see https://github.com/dbmdz/imageio-jnr/pull/226).