### PR TITLE
pom: bump version of spring-boot-starter-parent to latest 2.7.x release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.7</version>
+    <version>2.7.9</version>
   </parent>
 
   <name>DigitalCollections: Hymir IIIF Server</name>


### PR DESCRIPTION
Hi,

this PR updates version of `spring-boot-starter-parent` to latest 2.7.x release.

Note: current 3.x is not working due to build errors.