### PR TITLE
pom: rollback logstash to 7.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>7.3</version>
+      <version>7.2</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Hi,

due to currently undiscovered problems with spring profiles (other than local) we need to rollback logstash to 7.2.

More investigations will follow to get it working with >= 7.3.