### PR TITLE
pom: update ImageIO version to latest 0.6.6 release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,12 +158,12 @@
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-turbojpeg</artifactId>
-      <version>0.6.5</version>
+      <version>0.6.6</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.imageio</groupId>
       <artifactId>imageio-openjpeg</artifactId>
-      <version>0.6.5</version>
+      <version>0.6.6</version>
     </dependency>
     <dependency>
       <groupId>de.digitalcollections.iiif</groupId>


### PR DESCRIPTION
Hi,

this PR updates ImageIO version to latest 0.6.6 release to support transformations of corrupt (but recoverable) images.