### PR TITLE
Fix return code for HttpMediaTypeNotAcceptable

### DIFF
--- a/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
+++ b/src/main/java/de/digitalcollections/iiif/hymir/frontend/ExceptionAdvice.java
@@ -8,6 +8,7 @@ import de.digitalcollections.model.exception.ResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -58,6 +59,12 @@ public class ExceptionAdvice {
   @ResponseStatus(value = HttpStatus.BAD_REQUEST)
   @ExceptionHandler(UnsupportedOperationException.class)
   public void handleUnsupportedOperationException(Exception exception) {
+    // NOP
+  }
+
+  @ResponseStatus(value = HttpStatus.NOT_ACCEPTABLE)
+  @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
+  public void handleHttpMediaTypeNotAcceptableException(Exception exception) {
     // NOP
   }
 

--- a/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import de.digitalcollections.iiif.hymir.Application;
 import de.digitalcollections.iiif.hymir.TestConfiguration;
-import de.digitalcollections.iiif.hymir.image.frontend.IIIFImageApiController;
 import de.digitalcollections.iiif.hymir.presentation.business.PresentationServiceImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -67,13 +66,13 @@ public class IIIFPresentationApiControllerTest {
     requestHeaders.add("Accept", "application/something-strange");
 
     ResponseEntity<String> response =
-            restTemplate.exchange(
-                    "/presentation/"
-                            + IIIFPresentationApiController.VERSION
-                            + "/manifest-valid-data/manifest",
-                    HttpMethod.GET,
-                    new HttpEntity<>(requestHeaders),
-                    String.class);
+        restTemplate.exchange(
+            "/presentation/"
+                + IIIFPresentationApiController.VERSION
+                + "/manifest-valid-data/manifest",
+            HttpMethod.GET,
+            new HttpEntity<>(requestHeaders),
+            String.class);
     assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
   }
 }

--- a/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/hymir/presentation/frontend/IIIFPresentationApiControllerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import de.digitalcollections.iiif.hymir.Application;
 import de.digitalcollections.iiif.hymir.TestConfiguration;
+import de.digitalcollections.iiif.hymir.image.frontend.IIIFImageApiController;
 import de.digitalcollections.iiif.hymir.presentation.business.PresentationServiceImpl;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -12,8 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -58,5 +58,22 @@ public class IIIFPresentationApiControllerTest {
             String.class);
     assertThat(response.getHeaders().get("mani1")).containsExactly("mani-value1");
     assertThat(response.getHeaders().get("mani2")).containsExactly("mani-value2");
+  }
+
+  @Test
+  public void testManifestNotAcceptableHeader() {
+    HttpHeaders requestHeaders = new HttpHeaders();
+    requestHeaders.add("Host", "localhost");
+    requestHeaders.add("Accept", "application/something-strange");
+
+    ResponseEntity<String> response =
+            restTemplate.exchange(
+                    "/presentation/"
+                            + IIIFPresentationApiController.VERSION
+                            + "/manifest-valid-data/manifest",
+                    HttpMethod.GET,
+                    new HttpEntity<>(requestHeaders),
+                    String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_ACCEPTABLE);
   }
 }


### PR DESCRIPTION
Hi,

requests with a strange `Accept` header should correctly lead to a 406 return code. Internally, 406 is recognized, but due to "catch-all" logic, 500 will be returned.

This PR fixes and unit-test it.